### PR TITLE
Harden runtime lifecycle

### DIFF
--- a/src/main/java/com/github/havlli/EventPilot/command/onreadyevent/OnReadyEvent.java
+++ b/src/main/java/com/github/havlli/EventPilot/command/onreadyevent/OnReadyEvent.java
@@ -44,8 +44,7 @@ public class OnReadyEvent implements SlashCommand {
     }
 
     private Mono<Void> subscribeSchedulers() {
-        return scheduledTask.getSchedulersFlux()
-                .then();
+        return scheduledTask.start();
     }
 
     private Mono<Void> subscribeExistingInteractions() {

--- a/src/main/java/com/github/havlli/EventPilot/command/onreadyevent/ScheduledTask.java
+++ b/src/main/java/com/github/havlli/EventPilot/command/onreadyevent/ScheduledTask.java
@@ -3,22 +3,29 @@ package com.github.havlli.EventPilot.command.onreadyevent;
 import com.github.havlli.EventPilot.core.DiscordService;
 import com.github.havlli.EventPilot.entity.event.Event;
 import com.github.havlli.EventPilot.entity.event.EventService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 
+import jakarta.annotation.PreDestroy;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 @Component
 public class ScheduledTask {
 
+    private static final Logger LOG = LoggerFactory.getLogger(ScheduledTask.class);
     private final Integer intervalSeconds;
     private final EventService eventService;
     private final DiscordService discordService;
+    private final AtomicBoolean started = new AtomicBoolean(false);
+    private Disposable schedulerSubscription;
 
     public ScheduledTask(
             EventService eventService,
@@ -31,22 +38,39 @@ public class ScheduledTask {
     }
 
     public Flux<Void> getSchedulersFlux() {
-        Scheduler scheduler = Schedulers.newSingle("MainScheduler");
+        return Flux.interval(Duration.ofSeconds(intervalSeconds), Duration.ofSeconds(intervalSeconds))
+                .flatMap(__ -> handleExpiredEvents());
+    }
 
-        return handleExpiredEvents()
-                .delaySubscription(Duration.ofSeconds(intervalSeconds))
-                .repeat()
-                .subscribeOn(scheduler);
+    public Mono<Void> start() {
+        return Mono.fromRunnable(() -> {
+            if (started.compareAndSet(false, true)) {
+                schedulerSubscription = getSchedulersFlux()
+                        .doFinally(__ -> started.set(false))
+                        .subscribe();
+            }
+        });
+    }
+
+    @PreDestroy
+    public void stop() {
+        if (schedulerSubscription != null && !schedulerSubscription.isDisposed()) {
+            schedulerSubscription.dispose();
+        }
     }
 
     private Mono<Void> handleExpiredEvents() {
         return Mono.defer(() -> getExpiredEventList()
                 .flatMapMany(discordService::deactivateEvents)
                 .then()
-        );
+        ).onErrorResume(error -> {
+            LOG.error("Expired event scheduler cycle failed", error);
+            return Mono.empty();
+        });
     }
 
     private Mono<List<Event>> getExpiredEventList() {
-        return Mono.just(eventService.getExpiredEvents());
+        return Mono.fromCallable(eventService::getExpiredEvents)
+                .subscribeOn(Schedulers.boundedElastic());
     }
 }

--- a/src/main/java/com/github/havlli/EventPilot/command/onreadyevent/StartupTask.java
+++ b/src/main/java/com/github/havlli/EventPilot/command/onreadyevent/StartupTask.java
@@ -13,11 +13,13 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 @Component
 public class StartupTask {
 
     private static final Logger LOG = LoggerFactory.getLogger(StartupTask.class);
+    private final AtomicBoolean interactionsSubscribed = new AtomicBoolean(false);
     private final EventService eventService;
     private final GuildService guildService;
     private final EmbedGenerator embedGenerator;
@@ -37,10 +39,21 @@ public class StartupTask {
 
 
     public Mono<Void> subscribeEventInteractions() {
-        List<Event> events = eventService.getAllEvents();
-        events.forEach(embedGenerator::subscribeInteractions);
-        LOG.info("%d event interactions subscribed".formatted(events.size()));
-        return Mono.empty();
+        return Mono.fromRunnable(() -> {
+            if (!interactionsSubscribed.compareAndSet(false, true)) {
+                LOG.info("Existing event interactions are already subscribed");
+                return;
+            }
+
+            try {
+                List<Event> events = eventService.getAllEvents();
+                events.forEach(embedGenerator::subscribeInteractions);
+                LOG.info("%d event interactions subscribed".formatted(events.size()));
+            } catch (RuntimeException error) {
+                interactionsSubscribed.set(false);
+                throw error;
+            }
+        });
     }
 
     public Flux<Guild> handleNewGuilds() {

--- a/src/main/java/com/github/havlli/EventPilot/core/GlobalCommandListener.java
+++ b/src/main/java/com/github/havlli/EventPilot/core/GlobalCommandListener.java
@@ -2,11 +2,15 @@ package com.github.havlli.EventPilot.core;
 
 import com.github.havlli.EventPilot.command.SlashCommand;
 import discord4j.core.GatewayDiscordClient;
+import discord4j.core.event.domain.Event;
 import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.Comparator;
 import java.util.List;
@@ -16,6 +20,7 @@ import java.util.List;
 @DependsOn({"restClient"})
 public class GlobalCommandListener {
 
+    private static final Logger LOG = LoggerFactory.getLogger(GlobalCommandListener.class);
     private final List<SlashCommand> commands;
     private final GatewayDiscordClient client;
     private final Comparator<SlashCommand> typeComparator;
@@ -32,12 +37,35 @@ public class GlobalCommandListener {
 
     @PostConstruct
     private void registerListeners() {
-        createListeners().subscribe();
+        createListeners().subscribe(
+                __ -> {
+                },
+                error -> LOG.error("Discord listener registration failed", error)
+        );
     }
 
     public Flux<?> createListeners() {
         commands.sort(typeComparator);
         return Flux.fromIterable(commands)
-                .flatMap(command -> client.on(command.getEventType(), command::handle));
+                .flatMap(this::createListener);
+    }
+
+    private Flux<?> createListener(SlashCommand command) {
+        return client.on(command.getEventType(), event -> handleCommand(command, event))
+                .onErrorResume(error -> {
+                    LOG.error("Discord listener failed for command [{}]", command.getName(), error);
+                    return Flux.empty();
+                });
+    }
+
+    private Mono<?> handleCommand(SlashCommand command, Event event) {
+        try {
+            return command.handle(event)
+                    .doOnError(error -> LOG.error("Discord command [{}] failed", command.getName(), error))
+                    .onErrorResume(error -> Mono.empty());
+        } catch (RuntimeException error) {
+            LOG.error("Discord command [{}] failed before returning a response", command.getName(), error);
+            return Mono.empty();
+        }
     }
 }

--- a/src/main/java/com/github/havlli/EventPilot/core/GlobalCommandRegistrar.java
+++ b/src/main/java/com/github/havlli/EventPilot/core/GlobalCommandRegistrar.java
@@ -16,8 +16,10 @@ import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -26,6 +28,7 @@ import java.util.stream.Stream;
 @DependsOn("restClient")
 public class GlobalCommandRegistrar implements ApplicationRunner {
 
+    private static final Duration COMMAND_REGISTRATION_TIMEOUT = Duration.ofSeconds(30);
     private static final Logger LOG = LoggerFactory.getLogger(GlobalCommandRegistrar.class);
     private final RestClient restClient;
     private final PathMatchingResourcePatternResolver pathMatcher;
@@ -60,7 +63,10 @@ public class GlobalCommandRegistrar implements ApplicationRunner {
     }
 
     private Long getApplicationId() {
-        return restClient.getApplicationId().block();
+        return Objects.requireNonNull(
+                restClient.getApplicationId().block(COMMAND_REGISTRATION_TIMEOUT),
+                "Application id must be available before registering global commands"
+        );
     }
 
     private void overwriteGlobalApplicationCommands(CommandRegistrarSpec registrarSpec) throws IOException {
@@ -69,7 +75,8 @@ public class GlobalCommandRegistrar implements ApplicationRunner {
                 .bulkOverwriteGlobalApplicationCommand(registrarSpec.applicationId(), commands)
                 .doOnNext(data -> LOG.info("Successfully registered Global Command [%s]".formatted(data.name())))
                 .doOnError(e -> LOG.error("Failed to register global commands", e))
-                .subscribe();
+                .then()
+                .block(COMMAND_REGISTRATION_TIMEOUT);
     }
 
     private List<ApplicationCommandRequest> extractApplicationCommandRequests(CommandRegistrarSpec commandRegistrarSpec) throws IOException {

--- a/src/test/java/com/github/havlli/EventPilot/command/onreadyevent/OnReadyEventTest.java
+++ b/src/test/java/com/github/havlli/EventPilot/command/onreadyevent/OnReadyEventTest.java
@@ -44,7 +44,7 @@ class OnReadyEventTest {
         Guild guildMock = mock(Guild.class);
         when(startupTaskMock.handleNewGuilds()).thenReturn(Flux.just(guildMock));
         when(startupTaskMock.subscribeEventInteractions()).thenReturn(Mono.empty());
-        when(scheduledTaskMock.getSchedulersFlux()).thenReturn(Flux.empty());
+        when(scheduledTaskMock.start()).thenReturn(Mono.empty());
 
         // Act
         Mono<?> actualMono = underTest.handle(readyEventMock);
@@ -52,7 +52,7 @@ class OnReadyEventTest {
         // Assert
         verify(startupTaskMock, times(1)).handleNewGuilds();
         verify(startupTaskMock, times(1)).subscribeEventInteractions();
-        verify(scheduledTaskMock, times(1)).getSchedulersFlux();
+        verify(scheduledTaskMock, times(1)).start();
         StepVerifier.create(actualMono)
                 .verifyComplete();
     }

--- a/src/test/java/com/github/havlli/EventPilot/command/onreadyevent/StartupTaskTest.java
+++ b/src/test/java/com/github/havlli/EventPilot/command/onreadyevent/StartupTaskTest.java
@@ -81,6 +81,26 @@ class StartupTaskTest {
     }
 
     @Test
+    void subscribeEventInteractions_subscribesOnlyOnce_WhenCalledRepeatedly() {
+        // Arrange
+        Event eventMock = mock(Event.class);
+        List<Event> events = List.of(eventMock);
+        when(eventServiceMock.getAllEvents()).thenReturn(events);
+
+        // Act
+        StepVerifier.create(underTest.subscribeEventInteractions())
+                .expectSubscription()
+                .verifyComplete();
+        StepVerifier.create(underTest.subscribeEventInteractions())
+                .expectSubscription()
+                .verifyComplete();
+
+        // Assert
+        verify(eventServiceMock, times(1)).getAllEvents();
+        verify(embedGeneratorMock, times(1)).subscribeInteractions(eventMock);
+    }
+
+    @Test
     void handleNewGuilds_CallsGuildServiceForEachGuild_WhenOneOrMoreGuildsRetrievedFromClient() {
         // Arrange
         Guild guildOneMock = mock(Guild.class);

--- a/src/test/java/com/github/havlli/EventPilot/core/GlobalCommandListenerTest.java
+++ b/src/test/java/com/github/havlli/EventPilot/core/GlobalCommandListenerTest.java
@@ -8,6 +8,7 @@ import com.github.havlli.EventPilot.command.onreadyevent.StartupTask;
 import com.github.havlli.EventPilot.command.test.TestCommand;
 import discord4j.core.GatewayDiscordClient;
 import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;
+import org.reactivestreams.Publisher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -19,6 +20,7 @@ import reactor.test.StepVerifier;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -123,7 +125,7 @@ class GlobalCommandListenerTest {
     }
 
     @Test
-    void constructListeners_WithCommandHandlingError_ShouldHandleErrorGracefully() {
+    void constructListeners_WithListenerError_ShouldHandleErrorGracefully() {
         // Arrange
         SlashCommand errorCommand = mock(SlashCommand.class);
         errorCommand.setEventType(ChatInputInteractionEvent.class);
@@ -137,7 +139,32 @@ class GlobalCommandListenerTest {
         // Assert
         StepVerifier.create(actual)
                 .expectSubscription()
-                .expectError(RuntimeException.class)
-                .verify();
+                .verifyComplete();
+    }
+
+    @Test
+    void constructListeners_WithCommandHandlingError_ShouldHandleErrorGracefully() {
+        // Arrange
+        SlashCommand errorCommand = mock(SlashCommand.class);
+        ChatInputInteractionEvent event = mock(ChatInputInteractionEvent.class);
+        when(errorCommand.getName()).thenReturn("error-command");
+        doReturn(ChatInputInteractionEvent.class).when(errorCommand).getEventType();
+        when(errorCommand.handle(event)).thenReturn(Mono.error(new RuntimeException("Command handling error")));
+        when(client.on(eq(ChatInputInteractionEvent.class), any())).thenAnswer(invocation -> {
+            Function<ChatInputInteractionEvent, Publisher<?>> handler = invocation.getArgument(1);
+            return Flux.just(event)
+                    .flatMap(nextEvent -> Mono.from(handler.apply(nextEvent)));
+        });
+
+        slashCommands.add(errorCommand);
+
+        // Act
+        Flux<?> actual = underTest.createListeners();
+
+        // Assert
+        StepVerifier.create(actual)
+                .expectSubscription()
+                .verifyComplete();
+        verify(errorCommand, times(1)).handle(event);
     }
 }

--- a/src/test/java/com/github/havlli/EventPilot/core/GlobalCommandRegistrarTest.java
+++ b/src/test/java/com/github/havlli/EventPilot/core/GlobalCommandRegistrarTest.java
@@ -110,4 +110,18 @@ class GlobalCommandRegistrarTest {
 
         verifyNoInteractions(applicationServiceMock);
     }
+
+    @Test
+    void run_ShouldThrow_WhenBulkOverwriteFails() {
+        // Arrange
+        when(mockClient.getApplicationService()).thenReturn(applicationServiceMock);
+        when(mockClient.getApplicationId()).thenReturn(Mono.just(123L));
+        when(applicationServiceMock.bulkOverwriteGlobalApplicationCommand(anyLong(), anyList()))
+                .thenReturn(Flux.error(new RuntimeException("registration failed")));
+
+        // Assert
+        assertThatThrownBy(() -> underTest.run(applicationArguments))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("registration failed");
+    }
 }


### PR DESCRIPTION
Summary: isolate command listener failures, make startup registration fail predictably, and prevent duplicate startup scheduling. Verification: targeted runtime tests passed; full Maven verification passed.