### PR TITLE
Run coverage on pull requests

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,11 +5,13 @@ on:
   workflow_run:
     workflows: [Test Coverage]
     types: [completed]
+    branches:
+      - main
 
 jobs:
   build-image-on-test-success:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main') }}
     services:
       postgres:
         image: postgres:15-alpine

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -2,6 +2,11 @@ name: Test Coverage
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
   push:
     branches:
       - main
@@ -11,6 +16,8 @@ on:
 jobs:
   test-coverage:
     runs-on: ubuntu-latest
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     services:
       postgres:
         image: postgres:15-alpine
@@ -49,6 +56,7 @@ jobs:
         run: mvn -ntp -B verify
 
       - name: Upload coverage reports to Codecov
+        if: ${{ env.CODECOV_TOKEN != '' }}
         uses: codecov/codecov-action@v6
         env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          CODECOV_TOKEN: ${{ env.CODECOV_TOKEN }}


### PR DESCRIPTION
Summary: run the coverage workflow on pull requests and keep image publishing limited to successful main push coverage runs. Verification: workflow diff checked locally; GitHub Actions will validate the updated workflow.