### PR TITLE
[codex] add organizer event inspection commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ supporting operations, but the main product surface is the Discord server.
 - Existing participants can change roles without creating duplicate signup records.
 - Non-capacity states such as Absence, Late, and Tentative do not fill roster capacity.
 - Event lifecycle commands for close, reopen, cancel, delete, and expired cleanup.
+- Organizer discovery commands for listing events and inspecting detailed roster state.
+- Discord-side command permission defaults backed by server-side permission checks.
 - Scheduled reminders before event start time with roster and waitlist summary.
 - Expired event deactivation and stale database cleanup.
 - Flyway-managed PostgreSQL schema with constraints for participant consistency.
@@ -88,11 +90,12 @@ Absence
 5. Sign up from two Discord users or test accounts until the event reaches capacity.
 6. Sign up another user to show waitlist behavior.
 7. Change an existing confirmed user to `Absence` and show the next waitlisted user promoted.
-8. Run `/close-event`, then try another signup to show lifecycle protection.
-9. Run `/reopen-event` and show signups working again.
-10. Reduce `DISCORD_REMINDER_LEAD_MINUTES` in a local demo environment and create a near-future event
+8. Run `/list-events` and `/event-info` to show organizer visibility.
+9. Run `/close-event`, then try another signup to show lifecycle protection.
+10. Run `/reopen-event` and show signups working again.
+11. Reduce `DISCORD_REMINDER_LEAD_MINUTES` in a local demo environment and create a near-future event
     to show the reminder embed.
-11. Run `/cancel-event` or `/delete-event` to show organizer controls and cleanup.
+12. Run `/cancel-event` or `/delete-event` to show organizer controls and cleanup.
 
 Useful screenshots or GIFs for a portfolio page:
 
@@ -109,6 +112,8 @@ Useful screenshots or GIFs for a portfolio page:
 | --- | --- |
 | `/create-event` | Starts a private guided flow for creating a role-based event signup post. |
 | `/create-embed-type` | Creates a reusable role layout for event buttons and embed grouping. |
+| `/list-events status:<filter> limit:<count>` | Lists recent events in the current server with roster and waitlist counts. |
+| `/event-info message-id:<id>` | Shows detailed event status, roster groups, and waitlist for one signup post. |
 | `/close-event message-id:<id>` | Closes an event to prevent further signups without deleting the post. |
 | `/reopen-event message-id:<id>` | Reopens a previously closed event. |
 | `/cancel-event message-id:<id>` | Cancels an event without deleting its historical signup state. |
@@ -116,7 +121,8 @@ Useful screenshots or GIFs for a portfolio page:
 | `/clear-expired` | Deactivates expired event signups in the current channel. |
 
 The `message-id` is the Discord message ID of the event signup post. Event embeds also show the event
-ID so organizers can copy it when using lifecycle commands.
+ID so organizers can copy it when using lifecycle and inspection commands. Organizer commands require
+`Manage Channels`; command JSON also sets Discord `default_member_permissions` for supported clients.
 
 ## Signup Rules
 
@@ -154,6 +160,8 @@ Key implementation points:
 - Discord button handling is centralized through one global `ButtonInteractionEvent` path.
 - Signup mutation lives in `EventSignupService`, which makes capacity and waitlist behavior testable.
 - Repository lookups use locking where concurrent signup consistency matters.
+- Organizer inspection commands are guild-scoped so one server cannot read another server's event
+  state by message ID.
 - Scheduled work handles expired-event deactivation and reminder dispatch.
 - Discord message rendering is separated into generator/formatter classes.
 - Flyway migrations own schema evolution; test schema mirrors the migrated model.
@@ -164,6 +172,8 @@ Key implementation points:
   reminder, cleanup, and testing decisions behind the current design.
 - [Demo capture guide](docs/demo-capture.md) provides a repeatable script for recording portfolio
   screenshots or GIFs in a Discord test server.
+- [Live smoke test](docs/live-smoke-test.md) lists the real Discord checks to run before treating a
+  build as demo-ready.
 
 ## Technology Stack
 
@@ -309,6 +319,7 @@ Completed hardening areas:
 - stale event cleanup
 - scheduled reminders
 - Docker/Testcontainers verification
+- organizer event discovery and detailed event inspection
 
 Useful next improvements:
 

--- a/docs/live-smoke-test.md
+++ b/docs/live-smoke-test.md
@@ -1,0 +1,212 @@
+# Live Smoke Test
+
+Use this checklist to validate EventPilot against a real Discord test server. Keep the server,
+channel names, and users generic so the same run can also produce portfolio-safe screenshots.
+
+## Preconditions
+
+- Docker is running.
+- A Discord test server exists.
+- The bot is invited with `bot` and `applications.commands` scopes.
+- The bot can view channels, send messages, create embeds, read message history, and use slash
+  commands in the test server.
+- Organizer test users have `Manage Channels`; ordinary player test users do not.
+- `.env` exists locally and is not committed.
+
+Required local values:
+
+```dotenv
+DISCORD_BOT_TOKEN=...
+JWT_SECRET=...
+POSTGRES_DB=eventpilot
+POSTGRES_USER=eventpilot
+POSTGRES_PASSWORD=...
+```
+
+Optional fast-reminder values:
+
+```dotenv
+DISCORD_SCHEDULER_INTERVAL_SECONDS=10
+DISCORD_REMINDER_LEAD_MINUTES=5
+```
+
+## Startup
+
+1. Start the app and dependencies:
+
+```shell
+docker compose up -d
+```
+
+2. Confirm the bot appears online in the test server.
+3. Confirm slash commands are visible after Discord registration propagates.
+4. Confirm ordinary members do not see organizer commands where Discord applies
+   `default_member_permissions`.
+
+Expected organizer commands:
+
+```text
+/create-event
+/create-embed-type
+/list-events
+/event-info
+/close-event
+/reopen-event
+/cancel-event
+/delete-event
+/clear-expired
+```
+
+## Event Creation
+
+1. Run `/create-embed-type`.
+2. Create a small gaming layout:
+
+```json
+{
+  "-1": "Absence",
+  "-2": "Late",
+  "-3": "Tentative",
+  "1": "Tank",
+  "2": "Healer",
+  "3": "Melee",
+  "4": "Ranged",
+  "5": "Support"
+}
+```
+
+3. Run `/create-event`.
+4. Create a near-future event with capacity `2`.
+5. Post it into the test signup channel.
+
+Expected result:
+
+- event signup message is posted by the bot
+- status is `Open`
+- event ID is visible
+- role buttons are visible
+- roster count is `0/2`
+
+## Signup Lifecycle
+
+1. User A clicks a positive role such as Tank.
+2. User B clicks a positive role such as Healer.
+3. User C clicks a positive role after the event is full.
+
+Expected result:
+
+- User A and User B are confirmed
+- roster count is `2/2`
+- User C is waitlisted
+- waitlist shows User C and their preferred role
+
+Then:
+
+1. User A changes to `Absence`, `Late`, or `Tentative`.
+
+Expected result:
+
+- User A moves to the non-capacity role
+- User C is promoted from waitlist
+- roster count remains accurate
+
+## Organizer Discovery
+
+1. Run `/list-events`.
+
+Expected result:
+
+- response is ephemeral
+- only events from the current server are listed
+- default filter includes open and closed events
+- each row shows name, status, start time, channel, roster count, waitlist count, and message ID
+
+2. Run `/list-events status:all limit:10`.
+
+Expected result:
+
+- cancelled and expired events appear when present
+- no more than 10 events are shown
+
+3. Run `/event-info message-id:<event-message-id>`.
+
+Expected result:
+
+- response is ephemeral
+- details include status, start time, channel, leader, roster count, waitlist count, role groups,
+  and waitlisted users
+
+4. Run `/event-info message-id:<missing-id>`.
+
+Expected result:
+
+- response is `Event not found in this server.`
+
+## Lifecycle Controls
+
+1. Run `/close-event message-id:<event-message-id>`.
+2. Click a signup button as a player.
+
+Expected result:
+
+- event status changes to `Closed`
+- signup click receives an ephemeral blocked response
+
+Then:
+
+1. Run `/reopen-event message-id:<event-message-id>`.
+2. Click a signup button as a player.
+
+Expected result:
+
+- event status changes to `Open`
+- signup changes work again
+
+Then:
+
+1. Run `/cancel-event message-id:<event-message-id>`.
+
+Expected result:
+
+- event status changes to `Cancelled`
+- signup clicks are blocked
+- event history stays visible
+
+## Reminder
+
+1. Create or update an event inside the configured reminder lead window.
+2. Wait for the scheduler interval.
+
+Expected result:
+
+- a reminder message is posted
+- reminder includes start time, relative time, leader, status, confirmed count, waitlist count,
+  grouped roster, and waitlist
+- only one reminder is sent for the event
+
+## Stale Delete Cleanup
+
+1. Create an event.
+2. Delete the Discord event message manually.
+3. Run `/delete-event message-id:<deleted-message-id>`.
+
+Expected result:
+
+- response is `Event deleted!` if database state existed
+- repeating the command returns `Event not found!`
+
+## Automated Verification
+
+Run after the live pass:
+
+```shell
+mvn -ntp -Dmaven.repo.local=.m2/repository test
+mvn -ntp -Dmaven.repo.local=.m2/repository verify
+```
+
+`verify` requires Docker for Testcontainers.
+
+## If Live Credentials Are Unavailable
+
+Do not create or commit `.env` placeholders with real secrets. Leave this checklist as the live
+acceptance script and rely on automated verification for the current pass.

--- a/src/main/java/com/github/havlli/EventPilot/command/EventInfoCommand.java
+++ b/src/main/java/com/github/havlli/EventPilot/command/EventInfoCommand.java
@@ -4,30 +4,21 @@ import com.github.havlli.EventPilot.core.SimplePermissionValidator;
 import com.github.havlli.EventPilot.entity.event.EventService;
 import com.github.havlli.EventPilot.session.UserSessionValidator;
 import discord4j.common.util.Snowflake;
-import discord4j.core.event.domain.Event;
 import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;
 import discord4j.core.object.command.ApplicationCommandInteractionOption;
 import discord4j.core.object.entity.Message;
-import discord4j.core.spec.InteractionCallbackSpecDeferReplyMono;
-import discord4j.core.spec.InteractionFollowupCreateSpec;
-import discord4j.rest.util.Permission;
 import org.springframework.context.MessageSource;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
-import java.util.Locale;
 import java.util.Optional;
 
 @Component
-public class EventInfoCommand implements SlashCommand {
+public class EventInfoCommand extends OrganizerCommand {
 
     private static final String EVENT_NAME = "event-info";
     private static final String OPTION_MESSAGE_ID = "message-id";
-    private Class<? extends Event> eventType = ChatInputInteractionEvent.class;
-    private final SimplePermissionValidator permissionChecker;
-    private final UserSessionValidator userSessionValidator;
-    private final MessageSource messageSource;
     private final EventService eventService;
     private final OrganizerEventFormatter organizerEventFormatter;
 
@@ -38,43 +29,20 @@ public class EventInfoCommand implements SlashCommand {
             EventService eventService,
             OrganizerEventFormatter organizerEventFormatter
     ) {
-        this.permissionChecker = permissionChecker;
-        this.userSessionValidator = userSessionValidator;
-        this.messageSource = messageSource;
+        super(EVENT_NAME, permissionChecker, userSessionValidator, messageSource);
         this.eventService = eventService;
         this.organizerEventFormatter = organizerEventFormatter;
     }
 
     @Override
-    public String getName() {
-        return EVENT_NAME;
-    }
-
-    @Override
-    public Class<? extends Event> getEventType() {
-        return eventType;
-    }
-
-    @Override
-    public void setEventType(Class<? extends Event> eventType) {
-        this.eventType = eventType;
-    }
-
-    @Override
-    public Mono<?> handle(Event event) {
-        ChatInputInteractionEvent interactionEvent = (ChatInputInteractionEvent) event;
-        if (!interactionEvent.getCommandName().equals(EVENT_NAME)) {
-            return Mono.empty();
-        }
-
-        return deferInteractionWithEphemeralResponse(interactionEvent)
-                .then(validatePermissions(interactionEvent));
+    protected Mono<Message> processInteraction(ChatInputInteractionEvent event) {
+        return eventInfoInteraction(event);
     }
 
     public Mono<Message> eventInfoInteraction(ChatInputInteractionEvent event) {
-        Optional<Snowflake> guildId = event.getInteraction().getGuildId();
+        Optional<Snowflake> guildId = getGuildId(event);
         if (guildId.isEmpty()) {
-            return sendMessage(event, messageSource.getMessage("interaction.organizer.guild-only", null, Locale.ENGLISH));
+            return sendMessage(event, getMessage("interaction.organizer.guild-only"));
         }
 
         String eventId = targetMessageId(event);
@@ -83,20 +51,7 @@ public class EventInfoCommand implements SlashCommand {
                 .subscribeOn(Schedulers.boundedElastic())
                 .flatMap(eventOptional -> eventOptional
                         .map(foundEvent -> sendMessage(event, organizerEventFormatter.formatEventDetails(foundEvent)))
-                        .orElseGet(() -> sendMessage(event, messageSource.getMessage("interaction.event-info.event-not-found", null, Locale.ENGLISH))));
-    }
-
-    private InteractionCallbackSpecDeferReplyMono deferInteractionWithEphemeralResponse(ChatInputInteractionEvent event) {
-        return event.deferReply()
-                .withEphemeral(true);
-    }
-
-    private Mono<Message> validatePermissions(ChatInputInteractionEvent event) {
-        return permissionChecker.followupWith(validateSession(event), event, Permission.MANAGE_CHANNELS);
-    }
-
-    private Mono<Message> validateSession(ChatInputInteractionEvent event) {
-        return userSessionValidator.validateThenWrap(eventInfoInteraction(event), event);
+                        .orElseGet(() -> sendMessage(event, getMessage("interaction.event-info.event-not-found"))));
     }
 
     private String targetMessageId(ChatInputInteractionEvent event) {
@@ -104,12 +59,5 @@ public class EventInfoCommand implements SlashCommand {
                 .flatMap(ApplicationCommandInteractionOption::getValue)
                 .map(value -> Snowflake.of(value.asString()).asString())
                 .orElse(Snowflake.of(0).asString());
-    }
-
-    private Mono<Message> sendMessage(ChatInputInteractionEvent event, String content) {
-        return event.createFollowup(InteractionFollowupCreateSpec.builder()
-                .content(content)
-                .ephemeral(true)
-                .build());
     }
 }

--- a/src/main/java/com/github/havlli/EventPilot/command/EventInfoCommand.java
+++ b/src/main/java/com/github/havlli/EventPilot/command/EventInfoCommand.java
@@ -1,0 +1,115 @@
+package com.github.havlli.EventPilot.command;
+
+import com.github.havlli.EventPilot.core.SimplePermissionValidator;
+import com.github.havlli.EventPilot.entity.event.EventService;
+import com.github.havlli.EventPilot.session.UserSessionValidator;
+import discord4j.common.util.Snowflake;
+import discord4j.core.event.domain.Event;
+import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;
+import discord4j.core.object.command.ApplicationCommandInteractionOption;
+import discord4j.core.object.entity.Message;
+import discord4j.core.spec.InteractionCallbackSpecDeferReplyMono;
+import discord4j.core.spec.InteractionFollowupCreateSpec;
+import discord4j.rest.util.Permission;
+import org.springframework.context.MessageSource;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+import java.util.Locale;
+import java.util.Optional;
+
+@Component
+public class EventInfoCommand implements SlashCommand {
+
+    private static final String EVENT_NAME = "event-info";
+    private static final String OPTION_MESSAGE_ID = "message-id";
+    private Class<? extends Event> eventType = ChatInputInteractionEvent.class;
+    private final SimplePermissionValidator permissionChecker;
+    private final UserSessionValidator userSessionValidator;
+    private final MessageSource messageSource;
+    private final EventService eventService;
+    private final OrganizerEventFormatter organizerEventFormatter;
+
+    public EventInfoCommand(
+            SimplePermissionValidator permissionChecker,
+            UserSessionValidator userSessionValidator,
+            MessageSource messageSource,
+            EventService eventService,
+            OrganizerEventFormatter organizerEventFormatter
+    ) {
+        this.permissionChecker = permissionChecker;
+        this.userSessionValidator = userSessionValidator;
+        this.messageSource = messageSource;
+        this.eventService = eventService;
+        this.organizerEventFormatter = organizerEventFormatter;
+    }
+
+    @Override
+    public String getName() {
+        return EVENT_NAME;
+    }
+
+    @Override
+    public Class<? extends Event> getEventType() {
+        return eventType;
+    }
+
+    @Override
+    public void setEventType(Class<? extends Event> eventType) {
+        this.eventType = eventType;
+    }
+
+    @Override
+    public Mono<?> handle(Event event) {
+        ChatInputInteractionEvent interactionEvent = (ChatInputInteractionEvent) event;
+        if (!interactionEvent.getCommandName().equals(EVENT_NAME)) {
+            return Mono.empty();
+        }
+
+        return deferInteractionWithEphemeralResponse(interactionEvent)
+                .then(validatePermissions(interactionEvent));
+    }
+
+    public Mono<Message> eventInfoInteraction(ChatInputInteractionEvent event) {
+        Optional<Snowflake> guildId = event.getInteraction().getGuildId();
+        if (guildId.isEmpty()) {
+            return sendMessage(event, messageSource.getMessage("interaction.organizer.guild-only", null, Locale.ENGLISH));
+        }
+
+        String eventId = targetMessageId(event);
+
+        return Mono.fromSupplier(() -> eventService.getEventByIdForGuild(eventId, guildId.orElseThrow().asString()))
+                .subscribeOn(Schedulers.boundedElastic())
+                .flatMap(eventOptional -> eventOptional
+                        .map(foundEvent -> sendMessage(event, organizerEventFormatter.formatEventDetails(foundEvent)))
+                        .orElseGet(() -> sendMessage(event, messageSource.getMessage("interaction.event-info.event-not-found", null, Locale.ENGLISH))));
+    }
+
+    private InteractionCallbackSpecDeferReplyMono deferInteractionWithEphemeralResponse(ChatInputInteractionEvent event) {
+        return event.deferReply()
+                .withEphemeral(true);
+    }
+
+    private Mono<Message> validatePermissions(ChatInputInteractionEvent event) {
+        return permissionChecker.followupWith(validateSession(event), event, Permission.MANAGE_CHANNELS);
+    }
+
+    private Mono<Message> validateSession(ChatInputInteractionEvent event) {
+        return userSessionValidator.validateThenWrap(eventInfoInteraction(event), event);
+    }
+
+    private String targetMessageId(ChatInputInteractionEvent event) {
+        return event.getOption(OPTION_MESSAGE_ID)
+                .flatMap(ApplicationCommandInteractionOption::getValue)
+                .map(value -> Snowflake.of(value.asString()).asString())
+                .orElse(Snowflake.of(0).asString());
+    }
+
+    private Mono<Message> sendMessage(ChatInputInteractionEvent event, String content) {
+        return event.createFollowup(InteractionFollowupCreateSpec.builder()
+                .content(content)
+                .ephemeral(true)
+                .build());
+    }
+}

--- a/src/main/java/com/github/havlli/EventPilot/command/ListEventsCommand.java
+++ b/src/main/java/com/github/havlli/EventPilot/command/ListEventsCommand.java
@@ -5,13 +5,9 @@ import com.github.havlli.EventPilot.entity.event.EventService;
 import com.github.havlli.EventPilot.entity.event.EventStatus;
 import com.github.havlli.EventPilot.session.UserSessionValidator;
 import discord4j.common.util.Snowflake;
-import discord4j.core.event.domain.Event;
 import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;
 import discord4j.core.object.command.ApplicationCommandInteractionOption;
 import discord4j.core.object.entity.Message;
-import discord4j.core.spec.InteractionCallbackSpecDeferReplyMono;
-import discord4j.core.spec.InteractionFollowupCreateSpec;
-import discord4j.rest.util.Permission;
 import org.springframework.context.MessageSource;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
@@ -22,7 +18,7 @@ import java.util.Locale;
 import java.util.Optional;
 
 @Component
-public class ListEventsCommand implements SlashCommand {
+public class ListEventsCommand extends OrganizerCommand {
 
     private static final String EVENT_NAME = "list-events";
     private static final String OPTION_STATUS = "status";
@@ -30,10 +26,6 @@ public class ListEventsCommand implements SlashCommand {
     private static final String DEFAULT_STATUS = "active";
     private static final int DEFAULT_LIMIT = 5;
     private static final int MAXIMUM_LIMIT = 10;
-    private Class<? extends Event> eventType = ChatInputInteractionEvent.class;
-    private final SimplePermissionValidator permissionChecker;
-    private final UserSessionValidator userSessionValidator;
-    private final MessageSource messageSource;
     private final EventService eventService;
     private final OrganizerEventFormatter organizerEventFormatter;
 
@@ -44,43 +36,20 @@ public class ListEventsCommand implements SlashCommand {
             EventService eventService,
             OrganizerEventFormatter organizerEventFormatter
     ) {
-        this.permissionChecker = permissionChecker;
-        this.userSessionValidator = userSessionValidator;
-        this.messageSource = messageSource;
+        super(EVENT_NAME, permissionChecker, userSessionValidator, messageSource);
         this.eventService = eventService;
         this.organizerEventFormatter = organizerEventFormatter;
     }
 
     @Override
-    public String getName() {
-        return EVENT_NAME;
-    }
-
-    @Override
-    public Class<? extends Event> getEventType() {
-        return eventType;
-    }
-
-    @Override
-    public void setEventType(Class<? extends Event> eventType) {
-        this.eventType = eventType;
-    }
-
-    @Override
-    public Mono<?> handle(Event event) {
-        ChatInputInteractionEvent interactionEvent = (ChatInputInteractionEvent) event;
-        if (!interactionEvent.getCommandName().equals(EVENT_NAME)) {
-            return Mono.empty();
-        }
-
-        return deferInteractionWithEphemeralResponse(interactionEvent)
-                .then(validatePermissions(interactionEvent));
+    protected Mono<Message> processInteraction(ChatInputInteractionEvent event) {
+        return listEventsInteraction(event);
     }
 
     public Mono<Message> listEventsInteraction(ChatInputInteractionEvent event) {
-        Optional<Snowflake> guildId = event.getInteraction().getGuildId();
+        Optional<Snowflake> guildId = getGuildId(event);
         if (guildId.isEmpty()) {
-            return sendMessage(event, messageSource.getMessage("interaction.organizer.guild-only", null, Locale.ENGLISH));
+            return sendMessage(event, getMessage("interaction.organizer.guild-only"));
         }
 
         List<EventStatus> statuses = statusesFor(statusOption(event));
@@ -90,24 +59,11 @@ public class ListEventsCommand implements SlashCommand {
                 .subscribeOn(Schedulers.boundedElastic())
                 .flatMap(events -> {
                     if (events.isEmpty()) {
-                        return sendMessage(event, messageSource.getMessage("interaction.list-events.no-events", null, Locale.ENGLISH));
+                        return sendMessage(event, getMessage("interaction.list-events.no-events"));
                     }
 
                     return sendMessage(event, organizerEventFormatter.formatEventList(events));
                 });
-    }
-
-    private InteractionCallbackSpecDeferReplyMono deferInteractionWithEphemeralResponse(ChatInputInteractionEvent event) {
-        return event.deferReply()
-                .withEphemeral(true);
-    }
-
-    private Mono<Message> validatePermissions(ChatInputInteractionEvent event) {
-        return permissionChecker.followupWith(validateSession(event), event, Permission.MANAGE_CHANNELS);
-    }
-
-    private Mono<Message> validateSession(ChatInputInteractionEvent event) {
-        return userSessionValidator.validateThenWrap(listEventsInteraction(event), event);
     }
 
     private String statusOption(ChatInputInteractionEvent event) {
@@ -136,12 +92,5 @@ public class ListEventsCommand implements SlashCommand {
             case "active" -> List.of(EventStatus.OPEN, EventStatus.CLOSED);
             default -> List.of(EventStatus.OPEN, EventStatus.CLOSED);
         };
-    }
-
-    private Mono<Message> sendMessage(ChatInputInteractionEvent event, String content) {
-        return event.createFollowup(InteractionFollowupCreateSpec.builder()
-                .content(content)
-                .ephemeral(true)
-                .build());
     }
 }

--- a/src/main/java/com/github/havlli/EventPilot/command/ListEventsCommand.java
+++ b/src/main/java/com/github/havlli/EventPilot/command/ListEventsCommand.java
@@ -1,0 +1,147 @@
+package com.github.havlli.EventPilot.command;
+
+import com.github.havlli.EventPilot.core.SimplePermissionValidator;
+import com.github.havlli.EventPilot.entity.event.EventService;
+import com.github.havlli.EventPilot.entity.event.EventStatus;
+import com.github.havlli.EventPilot.session.UserSessionValidator;
+import discord4j.common.util.Snowflake;
+import discord4j.core.event.domain.Event;
+import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;
+import discord4j.core.object.command.ApplicationCommandInteractionOption;
+import discord4j.core.object.entity.Message;
+import discord4j.core.spec.InteractionCallbackSpecDeferReplyMono;
+import discord4j.core.spec.InteractionFollowupCreateSpec;
+import discord4j.rest.util.Permission;
+import org.springframework.context.MessageSource;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+@Component
+public class ListEventsCommand implements SlashCommand {
+
+    private static final String EVENT_NAME = "list-events";
+    private static final String OPTION_STATUS = "status";
+    private static final String OPTION_LIMIT = "limit";
+    private static final String DEFAULT_STATUS = "active";
+    private static final int DEFAULT_LIMIT = 5;
+    private static final int MAXIMUM_LIMIT = 10;
+    private Class<? extends Event> eventType = ChatInputInteractionEvent.class;
+    private final SimplePermissionValidator permissionChecker;
+    private final UserSessionValidator userSessionValidator;
+    private final MessageSource messageSource;
+    private final EventService eventService;
+    private final OrganizerEventFormatter organizerEventFormatter;
+
+    public ListEventsCommand(
+            SimplePermissionValidator permissionChecker,
+            UserSessionValidator userSessionValidator,
+            MessageSource messageSource,
+            EventService eventService,
+            OrganizerEventFormatter organizerEventFormatter
+    ) {
+        this.permissionChecker = permissionChecker;
+        this.userSessionValidator = userSessionValidator;
+        this.messageSource = messageSource;
+        this.eventService = eventService;
+        this.organizerEventFormatter = organizerEventFormatter;
+    }
+
+    @Override
+    public String getName() {
+        return EVENT_NAME;
+    }
+
+    @Override
+    public Class<? extends Event> getEventType() {
+        return eventType;
+    }
+
+    @Override
+    public void setEventType(Class<? extends Event> eventType) {
+        this.eventType = eventType;
+    }
+
+    @Override
+    public Mono<?> handle(Event event) {
+        ChatInputInteractionEvent interactionEvent = (ChatInputInteractionEvent) event;
+        if (!interactionEvent.getCommandName().equals(EVENT_NAME)) {
+            return Mono.empty();
+        }
+
+        return deferInteractionWithEphemeralResponse(interactionEvent)
+                .then(validatePermissions(interactionEvent));
+    }
+
+    public Mono<Message> listEventsInteraction(ChatInputInteractionEvent event) {
+        Optional<Snowflake> guildId = event.getInteraction().getGuildId();
+        if (guildId.isEmpty()) {
+            return sendMessage(event, messageSource.getMessage("interaction.organizer.guild-only", null, Locale.ENGLISH));
+        }
+
+        List<EventStatus> statuses = statusesFor(statusOption(event));
+        int limit = limitOption(event);
+
+        return Mono.fromSupplier(() -> eventService.getEventsForGuild(guildId.orElseThrow().asString(), statuses, limit))
+                .subscribeOn(Schedulers.boundedElastic())
+                .flatMap(events -> {
+                    if (events.isEmpty()) {
+                        return sendMessage(event, messageSource.getMessage("interaction.list-events.no-events", null, Locale.ENGLISH));
+                    }
+
+                    return sendMessage(event, organizerEventFormatter.formatEventList(events));
+                });
+    }
+
+    private InteractionCallbackSpecDeferReplyMono deferInteractionWithEphemeralResponse(ChatInputInteractionEvent event) {
+        return event.deferReply()
+                .withEphemeral(true);
+    }
+
+    private Mono<Message> validatePermissions(ChatInputInteractionEvent event) {
+        return permissionChecker.followupWith(validateSession(event), event, Permission.MANAGE_CHANNELS);
+    }
+
+    private Mono<Message> validateSession(ChatInputInteractionEvent event) {
+        return userSessionValidator.validateThenWrap(listEventsInteraction(event), event);
+    }
+
+    private String statusOption(ChatInputInteractionEvent event) {
+        return event.getOption(OPTION_STATUS)
+                .flatMap(ApplicationCommandInteractionOption::getValue)
+                .map(value -> value.asString().toLowerCase(Locale.ROOT))
+                .orElse(DEFAULT_STATUS);
+    }
+
+    private int limitOption(ChatInputInteractionEvent event) {
+        int requestedLimit = event.getOption(OPTION_LIMIT)
+                .flatMap(ApplicationCommandInteractionOption::getValue)
+                .map(value -> (int) value.asLong())
+                .orElse(DEFAULT_LIMIT);
+
+        return Math.max(1, Math.min(MAXIMUM_LIMIT, requestedLimit));
+    }
+
+    private List<EventStatus> statusesFor(String status) {
+        return switch (status) {
+            case "open" -> List.of(EventStatus.OPEN);
+            case "closed" -> List.of(EventStatus.CLOSED);
+            case "cancelled" -> List.of(EventStatus.CANCELLED);
+            case "expired" -> List.of(EventStatus.EXPIRED);
+            case "all" -> List.of();
+            case "active" -> List.of(EventStatus.OPEN, EventStatus.CLOSED);
+            default -> List.of(EventStatus.OPEN, EventStatus.CLOSED);
+        };
+    }
+
+    private Mono<Message> sendMessage(ChatInputInteractionEvent event, String content) {
+        return event.createFollowup(InteractionFollowupCreateSpec.builder()
+                .content(content)
+                .ephemeral(true)
+                .build());
+    }
+}

--- a/src/main/java/com/github/havlli/EventPilot/command/OrganizerCommand.java
+++ b/src/main/java/com/github/havlli/EventPilot/command/OrganizerCommand.java
@@ -1,0 +1,93 @@
+package com.github.havlli.EventPilot.command;
+
+import com.github.havlli.EventPilot.core.SimplePermissionValidator;
+import com.github.havlli.EventPilot.session.UserSessionValidator;
+import discord4j.common.util.Snowflake;
+import discord4j.core.event.domain.Event;
+import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;
+import discord4j.core.object.entity.Message;
+import discord4j.core.spec.InteractionCallbackSpecDeferReplyMono;
+import discord4j.core.spec.InteractionFollowupCreateSpec;
+import discord4j.rest.util.Permission;
+import org.springframework.context.MessageSource;
+import reactor.core.publisher.Mono;
+
+import java.util.Locale;
+import java.util.Optional;
+
+public abstract class OrganizerCommand implements SlashCommand {
+
+    private final String commandName;
+    private final SimplePermissionValidator permissionChecker;
+    private final UserSessionValidator userSessionValidator;
+    private final MessageSource messageSource;
+    private Class<? extends Event> eventType = ChatInputInteractionEvent.class;
+
+    protected OrganizerCommand(
+            String commandName,
+            SimplePermissionValidator permissionChecker,
+            UserSessionValidator userSessionValidator,
+            MessageSource messageSource
+    ) {
+        this.commandName = commandName;
+        this.permissionChecker = permissionChecker;
+        this.userSessionValidator = userSessionValidator;
+        this.messageSource = messageSource;
+    }
+
+    @Override
+    public String getName() {
+        return commandName;
+    }
+
+    @Override
+    public Class<? extends Event> getEventType() {
+        return eventType;
+    }
+
+    @Override
+    public void setEventType(Class<? extends Event> eventType) {
+        this.eventType = eventType;
+    }
+
+    @Override
+    public Mono<?> handle(Event event) {
+        ChatInputInteractionEvent interactionEvent = (ChatInputInteractionEvent) event;
+        if (!interactionEvent.getCommandName().equals(commandName)) {
+            return Mono.empty();
+        }
+
+        return deferInteractionWithEphemeralResponse(interactionEvent)
+                .then(validatePermissions(interactionEvent));
+    }
+
+    protected Optional<Snowflake> getGuildId(ChatInputInteractionEvent event) {
+        return event.getInteraction().getGuildId();
+    }
+
+    protected String getMessage(String key) {
+        return messageSource.getMessage(key, null, Locale.ENGLISH);
+    }
+
+    protected Mono<Message> sendMessage(ChatInputInteractionEvent event, String content) {
+        return event.createFollowup(InteractionFollowupCreateSpec.builder()
+                .content(content)
+                .ephemeral(true)
+                .build());
+    }
+
+    protected abstract Mono<Message> processInteraction(ChatInputInteractionEvent event);
+
+    private InteractionCallbackSpecDeferReplyMono deferInteractionWithEphemeralResponse(ChatInputInteractionEvent event) {
+        return event.deferReply()
+                .withEphemeral(true);
+    }
+
+    private Mono<Message> validatePermissions(ChatInputInteractionEvent event) {
+        return permissionChecker.followupWith(validateSession(event), event, Permission.MANAGE_CHANNELS);
+    }
+
+    private Mono<Message> validateSession(ChatInputInteractionEvent event) {
+        return userSessionValidator.validateThenWrap(processInteraction(event), event);
+    }
+}

--- a/src/main/java/com/github/havlli/EventPilot/command/OrganizerEventFormatter.java
+++ b/src/main/java/com/github/havlli/EventPilot/command/OrganizerEventFormatter.java
@@ -1,0 +1,199 @@
+package com.github.havlli.EventPilot.command;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.github.havlli.EventPilot.entity.embedtype.EmbedTypeService;
+import com.github.havlli.EventPilot.entity.event.Event;
+import com.github.havlli.EventPilot.entity.participant.Participant;
+import com.github.havlli.EventPilot.entity.participant.ParticipantStatus;
+import com.github.havlli.EventPilot.generator.EmbedFormatter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+public class OrganizerEventFormatter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OrganizerEventFormatter.class);
+    private static final int DISCORD_CONTENT_LIMIT = 1900;
+    private static final String TRUNCATION_SUFFIX = "\n... truncated";
+    private final EmbedFormatter embedFormatter;
+    private final EmbedTypeService embedTypeService;
+
+    public OrganizerEventFormatter(EmbedFormatter embedFormatter, EmbedTypeService embedTypeService) {
+        this.embedFormatter = embedFormatter;
+        this.embedTypeService = embedTypeService;
+    }
+
+    public String formatEventList(List<Event> events) {
+        String content = events.stream()
+                .map(this::formatEventListEntry)
+                .collect(Collectors.joining("\n"));
+
+        return truncate("Events:\n" + content);
+    }
+
+    public String formatEventDetails(Event event) {
+        Map<Integer, String> roleNames = roleNames(event);
+        String roles = formatRoleGroups(event, roleNames);
+        String waitlist = formatWaitlist(event, roleNames);
+
+        String content = """
+                Event: **%s**
+                ID: `%s`
+                Status: %s
+                Starts: %s (%s)
+                Channel: %s
+                Leader: %s
+                Roster: %s
+
+                Confirmed roles:
+                %s
+
+                Waitlist:
+                %s
+                """.formatted(
+                event.getName(),
+                event.getEventId(),
+                embedFormatter.status(event.getStatus()),
+                embedFormatter.dateTime(event.getDateTime()),
+                embedFormatter.relativeTime(event.getDateTime()),
+                formatChannel(event),
+                event.getAuthor(),
+                formatRoster(event),
+                roles,
+                waitlist
+        );
+
+        return truncate(content.strip());
+    }
+
+    private String formatEventListEntry(Event event) {
+        return "- **%s** | %s | %s | %s | %s | ID: `%s`".formatted(
+                event.getName(),
+                embedFormatter.status(event.getStatus()),
+                embedFormatter.dateTime(event.getDateTime()),
+                formatChannel(event),
+                formatRoster(event),
+                event.getEventId()
+        );
+    }
+
+    private String formatRoster(Event event) {
+        return "%d/%s confirmed, %d waitlisted".formatted(
+                confirmedCapacityCount(event),
+                event.getMemberSize(),
+                waitlistedCount(event)
+        );
+    }
+
+    private String formatRoleGroups(Event event, Map<Integer, String> roleNames) {
+        Map<Integer, List<Participant>> participantsByRole = event.getParticipants()
+                .stream()
+                .filter(this::isSignedUp)
+                .collect(Collectors.groupingBy(Participant::getRoleIndex));
+
+        if (participantsByRole.isEmpty()) {
+            return "No confirmed participants.";
+        }
+
+        return participantsByRole.entrySet()
+                .stream()
+                .sorted(Map.Entry.comparingByKey(this::compareRoleIndexes))
+                .map(entry -> "%s (%d): %s".formatted(
+                        roleName(entry.getKey(), roleNames),
+                        entry.getValue().size(),
+                        formatParticipants(entry.getValue())
+                ))
+                .collect(Collectors.joining("\n"));
+    }
+
+    private String formatParticipants(List<Participant> participants) {
+        return participants.stream()
+                .sorted(Comparator.comparing(Participant::getPosition))
+                .map(participant -> "`%d` %s".formatted(participant.getPosition(), participant.getUsername()))
+                .collect(Collectors.joining(", "));
+    }
+
+    private String formatWaitlist(Event event, Map<Integer, String> roleNames) {
+        String waitlisted = event.getParticipants()
+                .stream()
+                .filter(this::isWaitlisted)
+                .sorted(Comparator.comparing(Participant::getPosition))
+                .map(participant -> "`%d` %s - %s".formatted(
+                        participant.getPosition(),
+                        participant.getUsername(),
+                        roleName(participant.getRoleIndex(), roleNames)
+                ))
+                .collect(Collectors.joining("\n"));
+
+        return waitlisted.isBlank() ? "No waitlisted participants." : waitlisted;
+    }
+
+    private Map<Integer, String> roleNames(Event event) {
+        try {
+            return embedTypeService.getDeserializedMap(event.getEmbedType());
+        } catch (JsonProcessingException error) {
+            LOG.warn("Could not deserialize role names for event [{}]", event.getEventId(), error);
+            return Map.of();
+        }
+    }
+
+    private String roleName(Integer roleIndex, Map<Integer, String> roleNames) {
+        return roleNames.getOrDefault(roleIndex, "Role " + roleIndex);
+    }
+
+    private String formatChannel(Event event) {
+        if (event.getDestinationChannelId() == null || event.getDestinationChannelId().isBlank()) {
+            return "unknown channel";
+        }
+
+        return "<#%s>".formatted(event.getDestinationChannelId());
+    }
+
+    private int confirmedCapacityCount(Event event) {
+        return (int) event.getParticipants()
+                .stream()
+                .filter(participant -> isSignedUp(participant)
+                        && participant.getRoleIndex() != null
+                        && participant.getRoleIndex() > 0)
+                .count();
+    }
+
+    private int waitlistedCount(Event event) {
+        return (int) event.getParticipants()
+                .stream()
+                .filter(this::isWaitlisted)
+                .count();
+    }
+
+    private boolean isSignedUp(Participant participant) {
+        return participant.getStatus() == ParticipantStatus.SIGNED_UP;
+    }
+
+    private boolean isWaitlisted(Participant participant) {
+        return participant.getStatus() == ParticipantStatus.WAITLISTED;
+    }
+
+    private int compareRoleIndexes(Integer first, Integer second) {
+        if (first > 0 && second > 0) {
+            return Integer.compare(first, second);
+        }
+        if (first <= 0 && second <= 0) {
+            return Integer.compare(first, second);
+        }
+        return first > 0 ? -1 : 1;
+    }
+
+    private String truncate(String content) {
+        if (content.length() <= DISCORD_CONTENT_LIMIT) {
+            return content;
+        }
+
+        return content.substring(0, DISCORD_CONTENT_LIMIT - TRUNCATION_SUFFIX.length()) + TRUNCATION_SUFFIX;
+    }
+}

--- a/src/main/java/com/github/havlli/EventPilot/entity/event/EventDAO.java
+++ b/src/main/java/com/github/havlli/EventPilot/entity/event/EventDAO.java
@@ -14,6 +14,8 @@ public interface EventDAO {
     List<Event> getReminderCandidates(Instant reminderCutoff);
     boolean existsById(String id);
     List<Event> getLastFiveEvents();
+    List<Event> getEventsForGuild(String guildId, List<EventStatus> statuses, int limit);
     Optional<Event> findById(String id);
+    Optional<Event> findByIdAndGuildId(String id, String guildId);
     Optional<Event> findByIdForUpdate(String id);
 }

--- a/src/main/java/com/github/havlli/EventPilot/entity/event/EventJPADataAccessService.java
+++ b/src/main/java/com/github/havlli/EventPilot/entity/event/EventJPADataAccessService.java
@@ -1,5 +1,6 @@
 package com.github.havlli.EventPilot.entity.event;
 
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 
 import java.time.Instant;
@@ -9,6 +10,7 @@ import java.util.Optional;
 @Repository
 public class EventJPADataAccessService implements EventDAO {
 
+    private static final int MINIMUM_LIMIT = 1;
     private final EventRepository eventRepository;
 
     public EventJPADataAccessService(EventRepository eventRepository) {
@@ -61,8 +63,23 @@ public class EventJPADataAccessService implements EventDAO {
     }
 
     @Override
+    public List<Event> getEventsForGuild(String guildId, List<EventStatus> statuses, int limit) {
+        PageRequest pageRequest = PageRequest.of(0, Math.max(MINIMUM_LIMIT, limit));
+        if (statuses == null || statuses.isEmpty()) {
+            return eventRepository.findByGuildIdOrderByDateTimeAsc(guildId, pageRequest);
+        }
+
+        return eventRepository.findByGuildIdAndStatusInOrderByDateTimeAsc(guildId, statuses, pageRequest);
+    }
+
+    @Override
     public Optional<Event> findById(String id) {
         return eventRepository.findById(id);
+    }
+
+    @Override
+    public Optional<Event> findByIdAndGuildId(String id, String guildId) {
+        return eventRepository.findByIdAndGuildId(id, guildId);
     }
 
     @Override

--- a/src/main/java/com/github/havlli/EventPilot/entity/event/EventRepository.java
+++ b/src/main/java/com/github/havlli/EventPilot/entity/event/EventRepository.java
@@ -1,6 +1,7 @@
 package com.github.havlli.EventPilot.entity.event;
 
 import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
@@ -65,4 +66,36 @@ public interface EventRepository extends JpaRepository<Event, String> {
             ORDER BY e.eventId DESC LIMIT 5
             """)
     List<Event> findLastFiveEvents();
+
+    @Query("""
+            SELECT DISTINCT e FROM Event e
+            LEFT JOIN FETCH e.guild
+            LEFT JOIN FETCH e.embedType
+            WHERE e.guild.id = :guildId
+            ORDER BY e.dateTime ASC, e.eventId ASC
+            """)
+    List<Event> findByGuildIdOrderByDateTimeAsc(String guildId, Pageable pageable);
+
+    @Query("""
+            SELECT DISTINCT e FROM Event e
+            LEFT JOIN FETCH e.guild
+            LEFT JOIN FETCH e.embedType
+            WHERE e.guild.id = :guildId
+            AND e.status IN :statuses
+            ORDER BY e.dateTime ASC, e.eventId ASC
+            """)
+    List<Event> findByGuildIdAndStatusInOrderByDateTimeAsc(
+            String guildId,
+            List<EventStatus> statuses,
+            Pageable pageable
+    );
+
+    @Query("""
+            SELECT DISTINCT e FROM Event e
+            LEFT JOIN FETCH e.guild
+            LEFT JOIN FETCH e.embedType
+            WHERE e.eventId = :id
+            AND e.guild.id = :guildId
+            """)
+    Optional<Event> findByIdAndGuildId(String id, String guildId);
 }

--- a/src/main/java/com/github/havlli/EventPilot/entity/event/EventService.java
+++ b/src/main/java/com/github/havlli/EventPilot/entity/event/EventService.java
@@ -88,6 +88,14 @@ public class EventService {
         return eventDAO.getLastFiveEvents();
     }
 
+    public List<Event> getEventsForGuild(String guildId, List<EventStatus> statuses, int limit) {
+        return eventDAO.getEventsForGuild(guildId, statuses, limit);
+    }
+
+    public Optional<Event> getEventByIdForGuild(String id, String guildId) {
+        return eventDAO.findByIdAndGuildId(id, guildId);
+    }
+
     public Event updateEvent(String id, EventUpdateRequest updateRequest) {
         Optional<Event> eventOptional = eventDAO.findById(id);
 

--- a/src/main/resources/commands/cancel-event.json
+++ b/src/main/resources/commands/cancel-event.json
@@ -1,6 +1,7 @@
 {
   "name": "cancel-event",
   "description": "Cancel an event signup without deleting it.",
+  "default_member_permissions": "16",
   "options": [
     {
       "name": "message-id",

--- a/src/main/resources/commands/clear-expired.json
+++ b/src/main/resources/commands/clear-expired.json
@@ -1,4 +1,5 @@
 {
   "name": "clear-expired",
-  "description": "Delete expired event signups in this channel."
+  "description": "Delete expired event signups in this channel.",
+  "default_member_permissions": "16"
 }

--- a/src/main/resources/commands/create-embed-type.json
+++ b/src/main/resources/commands/create-embed-type.json
@@ -1,4 +1,5 @@
 {
   "name": "create-embed-type",
-  "description": "Create a reusable event role layout."
+  "description": "Create a reusable event role layout.",
+  "default_member_permissions": "16"
 }

--- a/src/main/resources/commands/create-event.json
+++ b/src/main/resources/commands/create-event.json
@@ -1,4 +1,5 @@
 {
   "name": "create-event",
-  "description": "Create a role-based event signup post."
+  "description": "Create a role-based event signup post.",
+  "default_member_permissions": "16"
 }

--- a/src/main/resources/commands/delete-event.json
+++ b/src/main/resources/commands/delete-event.json
@@ -1,6 +1,7 @@
 {
   "name": "delete-event",
   "description": "Delete an event signup by message ID.",
+  "default_member_permissions": "16",
   "options": [
     {
       "name": "message-id",

--- a/src/main/resources/commands/event-info.json
+++ b/src/main/resources/commands/event-info.json
@@ -1,6 +1,6 @@
 {
-  "name": "close-event",
-  "description": "Close an event signup without deleting it.",
+  "name": "event-info",
+  "description": "Show details for an event signup.",
   "default_member_permissions": "16",
   "options": [
     {

--- a/src/main/resources/commands/list-events.json
+++ b/src/main/resources/commands/list-events.json
@@ -1,0 +1,47 @@
+{
+  "name": "list-events",
+  "description": "List event signups in this server.",
+  "default_member_permissions": "16",
+  "options": [
+    {
+      "name": "status",
+      "description": "Filter events by lifecycle status",
+      "type": 3,
+      "required": false,
+      "choices": [
+        {
+          "name": "Active",
+          "value": "active"
+        },
+        {
+          "name": "Open",
+          "value": "open"
+        },
+        {
+          "name": "Closed",
+          "value": "closed"
+        },
+        {
+          "name": "Cancelled",
+          "value": "cancelled"
+        },
+        {
+          "name": "Expired",
+          "value": "expired"
+        },
+        {
+          "name": "All",
+          "value": "all"
+        }
+      ]
+    },
+    {
+      "name": "limit",
+      "description": "Maximum events to show",
+      "type": 4,
+      "required": false,
+      "min_value": 1,
+      "max_value": 10
+    }
+  ]
+}

--- a/src/main/resources/commands/reopen-event.json
+++ b/src/main/resources/commands/reopen-event.json
@@ -1,6 +1,7 @@
 {
   "name": "reopen-event",
   "description": "Reopen a closed event signup.",
+  "default_member_permissions": "16",
   "options": [
     {
       "name": "message-id",

--- a/src/main/resources/messages/messages_en.properties
+++ b/src/main/resources/messages/messages_en.properties
@@ -38,6 +38,10 @@ interaction.lifecycle.closed=Event closed!
 interaction.lifecycle.reopened=Event reopened!
 interaction.lifecycle.cancelled=Event cancelled!
 
+interaction.organizer.guild-only=This command can only be used in a Discord server.
+interaction.list-events.no-events=No matching events found in this server.
+interaction.event-info.event-not-found=Event not found in this server.
+
 sessions.already-active-session=You have already one active interaction, finish previous interaction to continue!
 
 permissions.not-valid=You do not have permission to use this command.

--- a/src/test/java/com/github/havlli/EventPilot/command/EventInfoCommandTest.java
+++ b/src/test/java/com/github/havlli/EventPilot/command/EventInfoCommandTest.java
@@ -1,0 +1,137 @@
+package com.github.havlli.EventPilot.command;
+
+import com.github.havlli.EventPilot.core.SimplePermissionValidator;
+import com.github.havlli.EventPilot.entity.event.Event;
+import com.github.havlli.EventPilot.entity.event.EventService;
+import com.github.havlli.EventPilot.session.UserSessionValidator;
+import discord4j.common.util.Snowflake;
+import discord4j.core.GatewayDiscordClient;
+import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;
+import discord4j.core.object.command.ApplicationCommandInteractionOption;
+import discord4j.core.object.command.Interaction;
+import discord4j.core.object.entity.Message;
+import discord4j.core.spec.InteractionFollowupCreateSpec;
+import discord4j.discordjson.json.ApplicationCommandInteractionOptionData;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.context.MessageSource;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.Locale;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class EventInfoCommandTest {
+
+    private AutoCloseable autoCloseable;
+    private EventInfoCommand underTest;
+    @Mock
+    private SimplePermissionValidator permissionChecker;
+    @Mock
+    private UserSessionValidator userSessionValidator;
+    @Mock
+    private MessageSource messageSource;
+    @Mock
+    private EventService eventService;
+    @Mock
+    private OrganizerEventFormatter organizerEventFormatter;
+    @Mock
+    private ChatInputInteractionEvent interactionEvent;
+    @Mock
+    private Interaction interaction;
+    @Mock
+    private GatewayDiscordClient client;
+    @Mock
+    private Message followupMessage;
+    @Captor
+    private ArgumentCaptor<InteractionFollowupCreateSpec> followupSpecCaptor;
+
+    @BeforeEach
+    void setUp() {
+        autoCloseable = MockitoAnnotations.openMocks(this);
+        underTest = new EventInfoCommand(
+                permissionChecker,
+                userSessionValidator,
+                messageSource,
+                eventService,
+                organizerEventFormatter
+        );
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        autoCloseable.close();
+    }
+
+    @Test
+    void eventInfoInteraction_ReturnsFormattedEventDetails_WhenEventExistsInGuild() {
+        // Arrange
+        Event event = mock(Event.class);
+        stubGuildInteraction();
+        when(interactionEvent.getOption("message-id")).thenReturn(Optional.of(stringOption("123")));
+        when(eventService.getEventByIdForGuild("123", "111")).thenReturn(Optional.of(event));
+        when(organizerEventFormatter.formatEventDetails(event)).thenReturn("Event details");
+        stubFollowup();
+
+        // Act
+        Mono<Message> actual = underTest.eventInfoInteraction(interactionEvent);
+
+        // Assert
+        StepVerifier.create(actual)
+                .expectNext(followupMessage)
+                .verifyComplete();
+        assertFollowup("Event details");
+    }
+
+    @Test
+    void eventInfoInteraction_RepliesEventNotFound_WhenEventDoesNotExistInGuild() {
+        // Arrange
+        stubGuildInteraction();
+        when(interactionEvent.getOption("message-id")).thenReturn(Optional.of(stringOption("123")));
+        when(eventService.getEventByIdForGuild("123", "111")).thenReturn(Optional.empty());
+        when(messageSource.getMessage("interaction.event-info.event-not-found", null, Locale.ENGLISH))
+                .thenReturn("Event not found in this server.");
+        stubFollowup();
+
+        // Act
+        Mono<Message> actual = underTest.eventInfoInteraction(interactionEvent);
+
+        // Assert
+        StepVerifier.create(actual)
+                .expectNext(followupMessage)
+                .verifyComplete();
+        assertFollowup("Event not found in this server.");
+    }
+
+    private void stubGuildInteraction() {
+        when(interactionEvent.getInteraction()).thenReturn(interaction);
+        when(interaction.getGuildId()).thenReturn(Optional.of(Snowflake.of("111")));
+    }
+
+    private void stubFollowup() {
+        when(interactionEvent.createFollowup(followupSpecCaptor.capture())).thenReturn(Mono.just(followupMessage));
+    }
+
+    private void assertFollowup(String expectedContent) {
+        InteractionFollowupCreateSpec spec = followupSpecCaptor.getValue();
+        assertThat(spec.contentOrElse("")).isEqualTo(expectedContent);
+        assertThat(spec.ephemeralOrElse(false)).isTrue();
+    }
+
+    private ApplicationCommandInteractionOption stringOption(String rawValue) {
+        ApplicationCommandInteractionOptionData data = ApplicationCommandInteractionOptionData.builder()
+                .name("message-id")
+                .type(3)
+                .value(rawValue)
+                .build();
+        return new ApplicationCommandInteractionOption(client, data, 111L, null);
+    }
+}

--- a/src/test/java/com/github/havlli/EventPilot/command/EventInfoCommandTest.java
+++ b/src/test/java/com/github/havlli/EventPilot/command/EventInfoCommandTest.java
@@ -7,10 +7,13 @@ import com.github.havlli.EventPilot.session.UserSessionValidator;
 import discord4j.common.util.Snowflake;
 import discord4j.core.GatewayDiscordClient;
 import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;
+import discord4j.core.event.domain.lifecycle.ReadyEvent;
 import discord4j.core.object.command.ApplicationCommandInteractionOption;
 import discord4j.core.object.command.Interaction;
 import discord4j.core.object.entity.Message;
+import discord4j.core.spec.InteractionCallbackSpecDeferReplyMono;
 import discord4j.core.spec.InteractionFollowupCreateSpec;
+import discord4j.rest.util.Permission;
 import discord4j.discordjson.json.ApplicationCommandInteractionOptionData;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,6 +30,8 @@ import java.util.Locale;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 class EventInfoCommandTest {
@@ -72,6 +77,44 @@ class EventInfoCommandTest {
     }
 
     @Test
+    void handle_ReturnsEmptyMono_WhenCommandNameDoesNotMatch() {
+        // Arrange
+        when(interactionEvent.getCommandName()).thenReturn("list-events");
+
+        // Act
+        Mono<Message> actual = underTest.handle(interactionEvent)
+                .cast(Message.class);
+
+        // Assert
+        StepVerifier.create(actual)
+                .expectSubscription()
+                .verifyComplete();
+        verifyNoInteractions(permissionChecker, userSessionValidator, eventService);
+    }
+
+    @Test
+    void handle_DelegatesThroughPermissionAndSessionValidators_WhenCommandNameMatches() {
+        // Arrange
+        Event event = mock(Event.class);
+        stubValidatedHandle();
+        when(interactionEvent.getOption("message-id")).thenReturn(Optional.of(stringOption("123")));
+        when(eventService.getEventByIdForGuild("123", "111")).thenReturn(Optional.of(event));
+        when(organizerEventFormatter.formatEventDetails(event)).thenReturn("Event details");
+        stubFollowup();
+
+        // Act
+        Mono<Message> actual = underTest.handle(interactionEvent)
+                .cast(Message.class);
+
+        // Assert
+        StepVerifier.create(actual)
+                .expectNext(followupMessage)
+                .verifyComplete();
+        verify(permissionChecker, times(1)).followupWith(any(), eq(interactionEvent), eq(Permission.MANAGE_CHANNELS));
+        verify(userSessionValidator, times(1)).validateThenWrap(any(), eq(interactionEvent));
+    }
+
+    @Test
     void eventInfoInteraction_ReturnsFormattedEventDetails_WhenEventExistsInGuild() {
         // Arrange
         Event event = mock(Event.class);
@@ -109,6 +152,73 @@ class EventInfoCommandTest {
                 .expectNext(followupMessage)
                 .verifyComplete();
         assertFollowup("Event not found in this server.");
+    }
+
+    @Test
+    void eventInfoInteraction_RepliesGuildOnly_WhenInteractionIsNotFromGuild() {
+        // Arrange
+        when(interactionEvent.getInteraction()).thenReturn(interaction);
+        when(interaction.getGuildId()).thenReturn(Optional.empty());
+        when(messageSource.getMessage("interaction.organizer.guild-only", null, Locale.ENGLISH))
+                .thenReturn("This command can only be used in a Discord server.");
+        stubFollowup();
+
+        // Act
+        Mono<Message> actual = underTest.eventInfoInteraction(interactionEvent);
+
+        // Assert
+        StepVerifier.create(actual)
+                .expectNext(followupMessage)
+                .verifyComplete();
+        assertFollowup("This command can only be used in a Discord server.");
+        verifyNoInteractions(eventService);
+    }
+
+    @Test
+    void eventInfoInteraction_UsesFallbackMessageId_WhenOptionIsMissing() {
+        // Arrange
+        Event event = mock(Event.class);
+        stubGuildInteraction();
+        when(interactionEvent.getOption("message-id")).thenReturn(Optional.empty());
+        when(eventService.getEventByIdForGuild("0", "111")).thenReturn(Optional.of(event));
+        when(organizerEventFormatter.formatEventDetails(event)).thenReturn("Fallback event details");
+        stubFollowup();
+
+        // Act
+        Mono<Message> actual = underTest.eventInfoInteraction(interactionEvent);
+
+        // Assert
+        StepVerifier.create(actual)
+                .expectNext(followupMessage)
+                .verifyComplete();
+        assertFollowup("Fallback event details");
+    }
+
+    @Test
+    void commandMetadata_CanBeReadAndUpdated() {
+        // Assert
+        assertThat(underTest.getName()).isEqualTo("event-info");
+        assertThat(underTest.getEventType()).isEqualTo(ChatInputInteractionEvent.class);
+
+        // Act
+        underTest.setEventType(ReadyEvent.class);
+
+        // Assert
+        assertThat(underTest.getEventType()).isEqualTo(ReadyEvent.class);
+    }
+
+    private void stubValidatedHandle() {
+        when(interactionEvent.getCommandName()).thenReturn("event-info");
+        stubGuildInteraction();
+        InteractionCallbackSpecDeferReplyMono deferReplyMono = mock(InteractionCallbackSpecDeferReplyMono.class);
+        when(interactionEvent.deferReply()).thenReturn(deferReplyMono);
+        when(deferReplyMono.withEphemeral(true)).thenReturn(deferReplyMono);
+        when(deferReplyMono.then(org.mockito.ArgumentMatchers.<Mono<Message>>any()))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(userSessionValidator.validateThenWrap(any(), eq(interactionEvent)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(permissionChecker.followupWith(any(), eq(interactionEvent), eq(Permission.MANAGE_CHANNELS)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
     }
 
     private void stubGuildInteraction() {

--- a/src/test/java/com/github/havlli/EventPilot/command/ListEventsCommandTest.java
+++ b/src/test/java/com/github/havlli/EventPilot/command/ListEventsCommandTest.java
@@ -1,0 +1,209 @@
+package com.github.havlli.EventPilot.command;
+
+import com.github.havlli.EventPilot.core.SimplePermissionValidator;
+import com.github.havlli.EventPilot.entity.event.Event;
+import com.github.havlli.EventPilot.entity.event.EventService;
+import com.github.havlli.EventPilot.entity.event.EventStatus;
+import com.github.havlli.EventPilot.session.UserSessionValidator;
+import discord4j.common.util.Snowflake;
+import discord4j.core.GatewayDiscordClient;
+import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;
+import discord4j.core.object.command.ApplicationCommandInteractionOption;
+import discord4j.core.object.command.Interaction;
+import discord4j.core.object.entity.Message;
+import discord4j.core.spec.InteractionCallbackSpecDeferReplyMono;
+import discord4j.core.spec.InteractionFollowupCreateSpec;
+import discord4j.discordjson.json.ApplicationCommandInteractionOptionData;
+import discord4j.rest.util.Permission;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.context.MessageSource;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+class ListEventsCommandTest {
+
+    private AutoCloseable autoCloseable;
+    private ListEventsCommand underTest;
+    @Mock
+    private SimplePermissionValidator permissionChecker;
+    @Mock
+    private UserSessionValidator userSessionValidator;
+    @Mock
+    private MessageSource messageSource;
+    @Mock
+    private EventService eventService;
+    @Mock
+    private OrganizerEventFormatter organizerEventFormatter;
+    @Mock
+    private ChatInputInteractionEvent interactionEvent;
+    @Mock
+    private Interaction interaction;
+    @Mock
+    private GatewayDiscordClient client;
+    @Mock
+    private Message followupMessage;
+    @Captor
+    private ArgumentCaptor<InteractionFollowupCreateSpec> followupSpecCaptor;
+
+    @BeforeEach
+    void setUp() {
+        autoCloseable = MockitoAnnotations.openMocks(this);
+        underTest = new ListEventsCommand(
+                permissionChecker,
+                userSessionValidator,
+                messageSource,
+                eventService,
+                organizerEventFormatter
+        );
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        autoCloseable.close();
+    }
+
+    @Test
+    void listEventsInteraction_UsesActiveFilterAndDefaultLimit_WhenOptionsAreMissing() {
+        // Arrange
+        Event event = mock(Event.class);
+        stubGuildInteraction();
+        when(interactionEvent.getOption("status")).thenReturn(Optional.empty());
+        when(interactionEvent.getOption("limit")).thenReturn(Optional.empty());
+        when(eventService.getEventsForGuild("111", List.of(EventStatus.OPEN, EventStatus.CLOSED), 5))
+                .thenReturn(List.of(event));
+        when(organizerEventFormatter.formatEventList(List.of(event))).thenReturn("Events:\n- Raid");
+        stubFollowup();
+
+        // Act
+        Mono<Message> actual = underTest.listEventsInteraction(interactionEvent);
+
+        // Assert
+        StepVerifier.create(actual)
+                .expectNext(followupMessage)
+                .verifyComplete();
+        assertFollowup("Events:\n- Raid");
+    }
+
+    @Test
+    void listEventsInteraction_UsesAllFilterAndClampedLimit_WhenOptionsArePresent() {
+        // Arrange
+        Event event = mock(Event.class);
+        stubGuildInteraction();
+        when(interactionEvent.getOption("status")).thenReturn(Optional.of(stringOption("all")));
+        when(interactionEvent.getOption("limit")).thenReturn(Optional.of(longOption(25)));
+        when(eventService.getEventsForGuild("111", List.of(), 10)).thenReturn(List.of(event));
+        when(organizerEventFormatter.formatEventList(List.of(event))).thenReturn("Events:\n- Raid");
+        stubFollowup();
+
+        // Act
+        Mono<Message> actual = underTest.listEventsInteraction(interactionEvent);
+
+        // Assert
+        StepVerifier.create(actual)
+                .expectNext(followupMessage)
+                .verifyComplete();
+        assertFollowup("Events:\n- Raid");
+    }
+
+    @Test
+    void listEventsInteraction_RepliesNoEvents_WhenNoMatchingEventsExist() {
+        // Arrange
+        stubGuildInteraction();
+        when(interactionEvent.getOption("status")).thenReturn(Optional.empty());
+        when(interactionEvent.getOption("limit")).thenReturn(Optional.empty());
+        when(eventService.getEventsForGuild("111", List.of(EventStatus.OPEN, EventStatus.CLOSED), 5))
+                .thenReturn(List.of());
+        when(messageSource.getMessage("interaction.list-events.no-events", null, Locale.ENGLISH))
+                .thenReturn("No matching events found in this server.");
+        stubFollowup();
+
+        // Act
+        Mono<Message> actual = underTest.listEventsInteraction(interactionEvent);
+
+        // Assert
+        StepVerifier.create(actual)
+                .expectNext(followupMessage)
+                .verifyComplete();
+        assertFollowup("No matching events found in this server.");
+    }
+
+    @Test
+    void handle_ReturnsPermissionDeniedMessageAndDoesNotQueryEvents_WhenPermissionValidatorRejects() {
+        // Arrange
+        Message deniedMessage = mock(Message.class);
+        stubValidatedHandle();
+        when(permissionChecker.followupWith(any(), eq(interactionEvent), eq(Permission.MANAGE_CHANNELS)))
+                .thenReturn(Mono.just(deniedMessage));
+
+        // Act
+        Mono<Message> actual = underTest.handle(interactionEvent)
+                .cast(Message.class);
+
+        // Assert
+        StepVerifier.create(actual)
+                .expectNext(deniedMessage)
+                .verifyComplete();
+        verify(eventService, never()).getEventsForGuild(any(), any(), anyInt());
+    }
+
+    private void stubValidatedHandle() {
+        when(interactionEvent.getCommandName()).thenReturn("list-events");
+        stubGuildInteraction();
+        when(interactionEvent.getOption("status")).thenReturn(Optional.empty());
+        when(interactionEvent.getOption("limit")).thenReturn(Optional.empty());
+        InteractionCallbackSpecDeferReplyMono deferReplyMono = mock(InteractionCallbackSpecDeferReplyMono.class);
+        when(interactionEvent.deferReply()).thenReturn(deferReplyMono);
+        when(deferReplyMono.withEphemeral(true)).thenReturn(deferReplyMono);
+        when(deferReplyMono.then(org.mockito.ArgumentMatchers.<Mono<Message>>any()))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(userSessionValidator.validateThenWrap(any(), eq(interactionEvent)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    private void stubGuildInteraction() {
+        when(interactionEvent.getInteraction()).thenReturn(interaction);
+        when(interaction.getGuildId()).thenReturn(Optional.of(Snowflake.of("111")));
+    }
+
+    private void stubFollowup() {
+        when(interactionEvent.createFollowup(followupSpecCaptor.capture())).thenReturn(Mono.just(followupMessage));
+    }
+
+    private void assertFollowup(String expectedContent) {
+        InteractionFollowupCreateSpec spec = followupSpecCaptor.getValue();
+        assertThat(spec.contentOrElse("")).isEqualTo(expectedContent);
+        assertThat(spec.ephemeralOrElse(false)).isTrue();
+    }
+
+    private ApplicationCommandInteractionOption stringOption(String rawValue) {
+        return option("status", 3, rawValue);
+    }
+
+    private ApplicationCommandInteractionOption longOption(long rawValue) {
+        return option("limit", 4, String.valueOf(rawValue));
+    }
+
+    private ApplicationCommandInteractionOption option(String name, int type, String rawValue) {
+        ApplicationCommandInteractionOptionData data = ApplicationCommandInteractionOptionData.builder()
+                .name(name)
+                .type(type)
+                .value(rawValue)
+                .build();
+        return new ApplicationCommandInteractionOption(client, data, 111L, null);
+    }
+}

--- a/src/test/java/com/github/havlli/EventPilot/command/ListEventsCommandTest.java
+++ b/src/test/java/com/github/havlli/EventPilot/command/ListEventsCommandTest.java
@@ -8,6 +8,7 @@ import com.github.havlli.EventPilot.session.UserSessionValidator;
 import discord4j.common.util.Snowflake;
 import discord4j.core.GatewayDiscordClient;
 import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;
+import discord4j.core.event.domain.lifecycle.ReadyEvent;
 import discord4j.core.object.command.ApplicationCommandInteractionOption;
 import discord4j.core.object.command.Interaction;
 import discord4j.core.object.entity.Message;
@@ -78,6 +79,22 @@ class ListEventsCommandTest {
     }
 
     @Test
+    void handle_ReturnsEmptyMono_WhenCommandNameDoesNotMatch() {
+        // Arrange
+        when(interactionEvent.getCommandName()).thenReturn("event-info");
+
+        // Act
+        Mono<Message> actual = underTest.handle(interactionEvent)
+                .cast(Message.class);
+
+        // Assert
+        StepVerifier.create(actual)
+                .expectSubscription()
+                .verifyComplete();
+        verifyNoInteractions(permissionChecker, userSessionValidator, eventService);
+    }
+
+    @Test
     void listEventsInteraction_UsesActiveFilterAndDefaultLimit_WhenOptionsAreMissing() {
         // Arrange
         Event event = mock(Event.class);
@@ -121,6 +138,37 @@ class ListEventsCommandTest {
     }
 
     @Test
+    void listEventsInteraction_UsesLowerClampedLimit_WhenLimitIsBelowMinimum() {
+        // Arrange
+        Event event = mock(Event.class);
+        stubGuildInteraction();
+        when(interactionEvent.getOption("status")).thenReturn(Optional.empty());
+        when(interactionEvent.getOption("limit")).thenReturn(Optional.of(longOption(0)));
+        when(eventService.getEventsForGuild("111", List.of(EventStatus.OPEN, EventStatus.CLOSED), 1))
+                .thenReturn(List.of(event));
+        when(organizerEventFormatter.formatEventList(List.of(event))).thenReturn("Events:\n- Raid");
+        stubFollowup();
+
+        // Act
+        Mono<Message> actual = underTest.listEventsInteraction(interactionEvent);
+
+        // Assert
+        StepVerifier.create(actual)
+                .expectNext(followupMessage)
+                .verifyComplete();
+        assertFollowup("Events:\n- Raid");
+    }
+
+    @Test
+    void listEventsInteraction_MapsStatusFiltersToEventStatuses() {
+        assertStatusFilter("open", List.of(EventStatus.OPEN));
+        assertStatusFilter("closed", List.of(EventStatus.CLOSED));
+        assertStatusFilter("cancelled", List.of(EventStatus.CANCELLED));
+        assertStatusFilter("expired", List.of(EventStatus.EXPIRED));
+        assertStatusFilter("unknown", List.of(EventStatus.OPEN, EventStatus.CLOSED));
+    }
+
+    @Test
     void listEventsInteraction_RepliesNoEvents_WhenNoMatchingEventsExist() {
         // Arrange
         stubGuildInteraction();
@@ -143,6 +191,26 @@ class ListEventsCommandTest {
     }
 
     @Test
+    void listEventsInteraction_RepliesGuildOnly_WhenInteractionIsNotFromGuild() {
+        // Arrange
+        when(interactionEvent.getInteraction()).thenReturn(interaction);
+        when(interaction.getGuildId()).thenReturn(Optional.empty());
+        when(messageSource.getMessage("interaction.organizer.guild-only", null, Locale.ENGLISH))
+                .thenReturn("This command can only be used in a Discord server.");
+        stubFollowup();
+
+        // Act
+        Mono<Message> actual = underTest.listEventsInteraction(interactionEvent);
+
+        // Assert
+        StepVerifier.create(actual)
+                .expectNext(followupMessage)
+                .verifyComplete();
+        assertFollowup("This command can only be used in a Discord server.");
+        verifyNoInteractions(eventService);
+    }
+
+    @Test
     void handle_ReturnsPermissionDeniedMessageAndDoesNotQueryEvents_WhenPermissionValidatorRejects() {
         // Arrange
         Message deniedMessage = mock(Message.class);
@@ -159,6 +227,37 @@ class ListEventsCommandTest {
                 .expectNext(deniedMessage)
                 .verifyComplete();
         verify(eventService, never()).getEventsForGuild(any(), any(), anyInt());
+    }
+
+    @Test
+    void commandMetadata_CanBeReadAndUpdated() {
+        // Assert
+        assertThat(underTest.getName()).isEqualTo("list-events");
+        assertThat(underTest.getEventType()).isEqualTo(ChatInputInteractionEvent.class);
+
+        // Act
+        underTest.setEventType(ReadyEvent.class);
+
+        // Assert
+        assertThat(underTest.getEventType()).isEqualTo(ReadyEvent.class);
+    }
+
+    private void assertStatusFilter(String status, List<EventStatus> expectedStatuses) {
+        Event event = mock(Event.class);
+        stubGuildInteraction();
+        when(interactionEvent.getOption("status")).thenReturn(Optional.of(stringOption(status)));
+        when(interactionEvent.getOption("limit")).thenReturn(Optional.empty());
+        when(eventService.getEventsForGuild("111", expectedStatuses, 5)).thenReturn(List.of(event));
+        when(organizerEventFormatter.formatEventList(List.of(event))).thenReturn("Events:\n- " + status);
+        stubFollowup();
+
+        Mono<Message> actual = underTest.listEventsInteraction(interactionEvent);
+
+        StepVerifier.create(actual)
+                .expectNext(followupMessage)
+                .verifyComplete();
+        assertFollowup("Events:\n- " + status);
+        verify(eventService, times(1)).getEventsForGuild("111", expectedStatuses, 5);
     }
 
     private void stubValidatedHandle() {

--- a/src/test/java/com/github/havlli/EventPilot/command/OrganizerEventFormatterTest.java
+++ b/src/test/java/com/github/havlli/EventPilot/command/OrganizerEventFormatterTest.java
@@ -1,0 +1,109 @@
+package com.github.havlli.EventPilot.command;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.github.havlli.EventPilot.entity.embedtype.EmbedType;
+import com.github.havlli.EventPilot.entity.embedtype.EmbedTypeService;
+import com.github.havlli.EventPilot.entity.event.Event;
+import com.github.havlli.EventPilot.entity.event.EventStatus;
+import com.github.havlli.EventPilot.entity.guild.Guild;
+import com.github.havlli.EventPilot.entity.participant.Participant;
+import com.github.havlli.EventPilot.entity.participant.ParticipantStatus;
+import com.github.havlli.EventPilot.generator.EmbedFormatter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+class OrganizerEventFormatterTest {
+
+    private AutoCloseable autoCloseable;
+    @Mock
+    private EmbedTypeService embedTypeService;
+    private OrganizerEventFormatter underTest;
+
+    @BeforeEach
+    void setUp() {
+        autoCloseable = MockitoAnnotations.openMocks(this);
+        underTest = new OrganizerEventFormatter(new EmbedFormatter(), embedTypeService);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        autoCloseable.close();
+    }
+
+    @Test
+    void formatEventList_IncludesRosterCountsStatusChannelAndMessageId() throws JsonProcessingException {
+        // Arrange
+        Event event = createEvent();
+        event.getParticipants().add(new Participant("1", "tank", 1, 1, event));
+        Participant waitlisted = new Participant("2", "backup", 2, 2, event);
+        waitlisted.setStatus(ParticipantStatus.WAITLISTED);
+        event.getParticipants().add(waitlisted);
+
+        // Act
+        String actual = underTest.formatEventList(List.of(event));
+
+        // Assert
+        assertThat(actual)
+                .contains("Events:")
+                .contains("**Raid Night**")
+                .contains("Open")
+                .contains("<#channel-1>")
+                .contains("1/2 confirmed, 1 waitlisted")
+                .contains("ID: `event-1`");
+    }
+
+    @Test
+    void formatEventDetails_IncludesRoleGroupsAndWaitlist() throws JsonProcessingException {
+        // Arrange
+        Event event = createEvent();
+        HashMap<Integer, String> roleNames = new HashMap<>();
+        roleNames.put(1, "Tank");
+        roleNames.put(2, "Healer");
+        when(embedTypeService.getDeserializedMap(event.getEmbedType())).thenReturn(roleNames);
+
+        event.getParticipants().add(new Participant("1", "tank", 1, 1, event));
+        Participant waitlisted = new Participant("2", "backup", 2, 2, event);
+        waitlisted.setStatus(ParticipantStatus.WAITLISTED);
+        event.getParticipants().add(waitlisted);
+
+        // Act
+        String actual = underTest.formatEventDetails(event);
+
+        // Assert
+        assertThat(actual)
+                .contains("Event: **Raid Night**")
+                .contains("ID: `event-1`")
+                .contains("Roster: 1/2 confirmed, 1 waitlisted")
+                .contains("Tank (1): `1` tank")
+                .contains("`2` backup - Healer");
+    }
+
+    private Event createEvent() {
+        Event event = new Event(
+                "event-1",
+                "Raid Night",
+                "description",
+                "leader",
+                Instant.ofEpochSecond(1_800_000_000L),
+                "channel-1",
+                null,
+                "2",
+                new ArrayList<>(),
+                new Guild("guild-1", "guild"),
+                new EmbedType(1L, "raid", "{}", null)
+        );
+        event.setStatus(EventStatus.OPEN);
+        return event;
+    }
+}

--- a/src/test/java/com/github/havlli/EventPilot/command/OrganizerEventFormatterTest.java
+++ b/src/test/java/com/github/havlli/EventPilot/command/OrganizerEventFormatterTest.java
@@ -19,6 +19,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -89,14 +90,101 @@ class OrganizerEventFormatterTest {
                 .contains("`2` backup - Healer");
     }
 
+    @Test
+    void formatEventDetails_UsesEmptyStateAndUnknownChannel_WhenEventHasNoParticipantsOrChannel() throws JsonProcessingException {
+        // Arrange
+        Event event = createEventWithChannel(null);
+        when(embedTypeService.getDeserializedMap(event.getEmbedType())).thenReturn(new HashMap<>());
+
+        // Act
+        String actual = underTest.formatEventDetails(event);
+
+        // Assert
+        assertThat(actual)
+                .contains("Channel: unknown channel")
+                .contains("Roster: 0/2 confirmed, 0 waitlisted")
+                .contains("No confirmed participants.")
+                .contains("No waitlisted participants.");
+    }
+
+    @Test
+    void formatEventDetails_UsesFallbackRoleNames_WhenRoleNamesCannotBeParsed() throws JsonProcessingException {
+        // Arrange
+        Event event = createEvent();
+        when(embedTypeService.getDeserializedMap(event.getEmbedType()))
+                .thenThrow(new JsonProcessingException("invalid role json") { });
+
+        event.getParticipants().add(new Participant("1", "healer", 1, 2, event));
+        event.getParticipants().add(new Participant("2", "tank", 2, 1, event));
+        event.getParticipants().add(new Participant("3", "late", 3, -2, event));
+        event.getParticipants().add(new Participant("4", "absence", 4, -1, event));
+        Participant waitlisted = new Participant("5", "backup", 5, 99, event);
+        waitlisted.setStatus(ParticipantStatus.WAITLISTED);
+        event.getParticipants().add(waitlisted);
+
+        // Act
+        String actual = underTest.formatEventDetails(event);
+
+        // Assert
+        assertThat(actual)
+                .contains("Role 1 (1): `2` tank")
+                .contains("Role 2 (1): `1` healer")
+                .contains("Role -2 (1): `3` late")
+                .contains("Role -1 (1): `4` absence")
+                .contains("`5` backup - Role 99");
+    }
+
+    @Test
+    void formatEventList_TruncatesContent_WhenDiscordMessageWouldBeTooLong() {
+        // Arrange
+        List<Event> events = IntStream.range(0, 80)
+                .mapToObj(index -> createEventWithName("Raid Night " + index))
+                .toList();
+
+        // Act
+        String actual = underTest.formatEventList(events);
+
+        // Assert
+        assertThat(actual)
+                .hasSize(1900)
+                .endsWith("\n... truncated");
+    }
+
+    @Test
+    void formatEventList_DoesNotCountNonCapacityOrNullRoleParticipantsAsConfirmed() {
+        // Arrange
+        Event event = createEvent();
+        event.getParticipants().add(new Participant("1", "tank", 1, 1, event));
+        event.getParticipants().add(new Participant("2", "late", 2, -1, event));
+        event.getParticipants().add(new Participant("3", "missing-role", 3, null, event));
+
+        // Act
+        String actual = underTest.formatEventList(List.of(event));
+
+        // Assert
+        assertThat(actual).contains("1/2 confirmed, 0 waitlisted");
+    }
+
     private Event createEvent() {
+        return createEventWithChannel("channel-1");
+    }
+
+    private Event createEventWithName(String name) {
+        return createEvent("event-" + name.hashCode(), name, "channel-1");
+    }
+
+    private Event createEventWithChannel(String channelId) {
+        return createEvent("event-1", "Raid Night", channelId);
+    }
+
+    private Event createEvent(String eventId, String name, String channelId) {
         Event event = new Event(
-                "event-1",
-                "Raid Night",
+                eventId,
+                name,
                 "description",
                 "leader",
                 Instant.ofEpochSecond(1_800_000_000L),
-                "channel-1",
+                channelId,
                 null,
                 "2",
                 new ArrayList<>(),

--- a/src/test/java/com/github/havlli/EventPilot/core/GlobalCommandRegistrarTest.java
+++ b/src/test/java/com/github/havlli/EventPilot/core/GlobalCommandRegistrarTest.java
@@ -79,8 +79,12 @@ class GlobalCommandRegistrarTest {
                         "create-embed-type",
                         "create-event",
                         "delete-event",
+                        "event-info",
+                        "list-events",
                         "reopen-event"
                 );
+        assertThat(capturedCommands)
+                .allSatisfy(command -> assertThat(command.defaultMemberPermissions()).contains("16"));
     }
 
     @Test

--- a/src/test/java/com/github/havlli/EventPilot/entity/event/EventJPADataAccessServiceTest.java
+++ b/src/test/java/com/github/havlli/EventPilot/entity/event/EventJPADataAccessServiceTest.java
@@ -1,5 +1,6 @@
 package com.github.havlli.EventPilot.entity.event;
 
+import org.springframework.data.domain.PageRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -10,6 +11,7 @@ import org.mockito.MockitoAnnotations;
 import java.time.Instant;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 class EventJPADataAccessServiceTest {
@@ -123,6 +125,58 @@ class EventJPADataAccessServiceTest {
     }
 
     @Test
+    void getEventsForGuild_DelegatesToAllGuildEvents_WhenStatusesAreNullAndClampsLimit() {
+        // Arrange
+        Event event = mock(Event.class);
+        when(eventRepository.findByGuildIdOrderByDateTimeAsc("guild-1", PageRequest.of(0, 1)))
+                .thenReturn(List.of(event));
+
+        // Act
+        List<Event> actual = underTest.getEventsForGuild("guild-1", null, 0);
+
+        // Assert
+        assertThat(actual).containsExactly(event);
+        verify(eventRepository, times(1))
+                .findByGuildIdOrderByDateTimeAsc("guild-1", PageRequest.of(0, 1));
+        verify(eventRepository, never()).findByGuildIdAndStatusInOrderByDateTimeAsc(any(), any(), any());
+    }
+
+    @Test
+    void getEventsForGuild_DelegatesToAllGuildEvents_WhenStatusesAreEmpty() {
+        // Arrange
+        Event event = mock(Event.class);
+        when(eventRepository.findByGuildIdOrderByDateTimeAsc("guild-1", PageRequest.of(0, 5)))
+                .thenReturn(List.of(event));
+
+        // Act
+        List<Event> actual = underTest.getEventsForGuild("guild-1", List.of(), 5);
+
+        // Assert
+        assertThat(actual).containsExactly(event);
+        verify(eventRepository, times(1))
+                .findByGuildIdOrderByDateTimeAsc("guild-1", PageRequest.of(0, 5));
+        verify(eventRepository, never()).findByGuildIdAndStatusInOrderByDateTimeAsc(any(), any(), any());
+    }
+
+    @Test
+    void getEventsForGuild_DelegatesToStatusFilteredGuildEvents() {
+        // Arrange
+        Event event = mock(Event.class);
+        List<EventStatus> statuses = List.of(EventStatus.OPEN, EventStatus.CLOSED);
+        when(eventRepository.findByGuildIdAndStatusInOrderByDateTimeAsc("guild-1", statuses, PageRequest.of(0, 5)))
+                .thenReturn(List.of(event));
+
+        // Act
+        List<Event> actual = underTest.getEventsForGuild("guild-1", statuses, 5);
+
+        // Assert
+        assertThat(actual).containsExactly(event);
+        verify(eventRepository, times(1))
+                .findByGuildIdAndStatusInOrderByDateTimeAsc("guild-1", statuses, PageRequest.of(0, 5));
+        verify(eventRepository, never()).findByGuildIdOrderByDateTimeAsc(any(), any());
+    }
+
+    @Test
     void findById() {
         // Arrange
         String eventId = "1234";
@@ -132,6 +186,18 @@ class EventJPADataAccessServiceTest {
 
         // Assert
         verify(eventRepository, times(1)).findById(eventId);
+    }
+
+    @Test
+    void findByIdAndGuildId() {
+        // Arrange
+        String eventId = "1234";
+
+        // Act
+        underTest.findByIdAndGuildId(eventId, "guild-1");
+
+        // Assert
+        verify(eventRepository, times(1)).findByIdAndGuildId(eventId, "guild-1");
     }
 
     @Test

--- a/src/test/java/com/github/havlli/EventPilot/entity/event/EventRepositoryIT.java
+++ b/src/test/java/com/github/havlli/EventPilot/entity/event/EventRepositoryIT.java
@@ -8,6 +8,7 @@ import com.github.havlli.EventPilot.entity.guild.Guild;
 import com.github.havlli.EventPilot.entity.guild.GuildRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -422,6 +423,109 @@ class EventRepositoryIT extends TestDatabaseContainer {
                 fetchedFutureOutsideCutoffEvent,
                 fetchedPastEvent
         );
+    }
+
+    @Test
+    public void findByGuildIdAndStatusInOrderByDateTimeAsc_ReturnsGuildScopedStatusFilteredEvents() {
+        // Arrange
+        Instant instantNow = timeTester.getInstantNowFromSystem();
+        Guild targetGuild = new Guild("guild-1", "target");
+        Guild otherGuild = new Guild("guild-2", "other");
+        EmbedType embedType = new EmbedType(
+                1L,
+                "test",
+                "{\"-1\":\"Absence\",\"-2\":\"Late\",\"1\":\"Tank\",\"-3\":\"Tentative\",\"2\":\"Melee\",\"3\":\"Ranged\",\"4\":\"Healer\",\"5\":\"Support\"}",
+                new ArrayList<>()
+        );
+
+        Event laterOpenEvent = createRepositoryEvent("300", "later-open", instantNow.plus(30, ChronoUnit.MINUTES), targetGuild, embedType);
+        Event fetchedLaterOpenEvent = saveEventToDatabase(laterOpenEvent, targetGuild, embedType);
+
+        Event earlierClosedEvent = createRepositoryEvent("100", "earlier-closed", instantNow.plus(10, ChronoUnit.MINUTES), targetGuild, embedType);
+        earlierClosedEvent.setStatus(EventStatus.CLOSED);
+        Event fetchedEarlierClosedEvent = saveEventToDatabase(earlierClosedEvent, targetGuild, embedType);
+
+        Event cancelledEvent = createRepositoryEvent("200", "cancelled", instantNow.plus(20, ChronoUnit.MINUTES), targetGuild, embedType);
+        cancelledEvent.setStatus(EventStatus.CANCELLED);
+        Event fetchedCancelledEvent = saveEventToDatabase(cancelledEvent, targetGuild, embedType);
+
+        Event otherGuildEvent = createRepositoryEvent("400", "other-guild", instantNow.plus(5, ChronoUnit.MINUTES), otherGuild, embedType);
+        Event fetchedOtherGuildEvent = saveEventToDatabase(otherGuildEvent, otherGuild, embedType);
+
+        // Act
+        List<Event> actual = underTest.findByGuildIdAndStatusInOrderByDateTimeAsc(
+                "guild-1",
+                List.of(EventStatus.OPEN, EventStatus.CLOSED),
+                PageRequest.of(0, 10)
+        );
+
+        // Assert
+        assertThat(actual).containsExactly(fetchedEarlierClosedEvent, fetchedLaterOpenEvent);
+        assertThat(actual).doesNotContain(fetchedCancelledEvent, fetchedOtherGuildEvent);
+    }
+
+    @Test
+    public void findByGuildIdOrderByDateTimeAsc_ReturnsLimitedGuildScopedEvents() {
+        // Arrange
+        Instant instantNow = timeTester.getInstantNowFromSystem();
+        Guild targetGuild = new Guild("guild-1", "target");
+        Guild otherGuild = new Guild("guild-2", "other");
+        EmbedType embedType = new EmbedType(
+                1L,
+                "test",
+                "{\"-1\":\"Absence\",\"-2\":\"Late\",\"1\":\"Tank\",\"-3\":\"Tentative\",\"2\":\"Melee\",\"3\":\"Ranged\",\"4\":\"Healer\",\"5\":\"Support\"}",
+                new ArrayList<>()
+        );
+
+        Event firstEvent = createRepositoryEvent("100", "first", instantNow.plus(10, ChronoUnit.MINUTES), targetGuild, embedType);
+        Event fetchedFirstEvent = saveEventToDatabase(firstEvent, targetGuild, embedType);
+
+        Event secondEvent = createRepositoryEvent("200", "second", instantNow.plus(20, ChronoUnit.MINUTES), targetGuild, embedType);
+        Event fetchedSecondEvent = saveEventToDatabase(secondEvent, targetGuild, embedType);
+
+        Event thirdEvent = createRepositoryEvent("300", "third", instantNow.plus(30, ChronoUnit.MINUTES), targetGuild, embedType);
+        Event fetchedThirdEvent = saveEventToDatabase(thirdEvent, targetGuild, embedType);
+
+        Event otherGuildEvent = createRepositoryEvent("400", "other-guild", instantNow.plus(5, ChronoUnit.MINUTES), otherGuild, embedType);
+        Event fetchedOtherGuildEvent = saveEventToDatabase(otherGuildEvent, otherGuild, embedType);
+
+        // Act
+        List<Event> actual = underTest.findByGuildIdOrderByDateTimeAsc(
+                "guild-1",
+                PageRequest.of(0, 2)
+        );
+
+        // Assert
+        assertThat(actual).containsExactly(fetchedFirstEvent, fetchedSecondEvent);
+        assertThat(actual).doesNotContain(fetchedThirdEvent, fetchedOtherGuildEvent);
+    }
+
+    @Test
+    public void findByIdAndGuildId_ReturnsOnlyMatchingGuildEvent() {
+        // Arrange
+        Instant instantNow = timeTester.getInstantNowFromSystem();
+        Guild targetGuild = new Guild("guild-1", "target");
+        Guild otherGuild = new Guild("guild-2", "other");
+        EmbedType embedType = new EmbedType(
+                1L,
+                "test",
+                "{\"-1\":\"Absence\",\"-2\":\"Late\",\"1\":\"Tank\",\"-3\":\"Tentative\",\"2\":\"Melee\",\"3\":\"Ranged\",\"4\":\"Healer\",\"5\":\"Support\"}",
+                new ArrayList<>()
+        );
+
+        Event targetEvent = createRepositoryEvent("100", "target", instantNow.plus(10, ChronoUnit.MINUTES), targetGuild, embedType);
+        Event fetchedTargetEvent = saveEventToDatabase(targetEvent, targetGuild, embedType);
+
+        Event otherGuildEvent = createRepositoryEvent("200", "other-guild", instantNow.plus(10, ChronoUnit.MINUTES), otherGuild, embedType);
+        saveEventToDatabase(otherGuildEvent, otherGuild, embedType);
+
+        // Act
+        Optional<Event> actual = underTest.findByIdAndGuildId("100", "guild-1");
+        Optional<Event> wrongGuild = underTest.findByIdAndGuildId("100", "guild-2");
+
+        // Assert
+        assertThat(actual).contains(fetchedTargetEvent);
+        assertThat(wrongGuild).isEmpty();
     }
 
     @Test

--- a/src/test/java/com/github/havlli/EventPilot/entity/event/EventServiceTest.java
+++ b/src/test/java/com/github/havlli/EventPilot/entity/event/EventServiceTest.java
@@ -202,6 +202,35 @@ class EventServiceTest {
     }
 
     @Test
+    void getEventsForGuild_DelegatesToDao() {
+        // Arrange
+        List<EventStatus> statuses = List.of(EventStatus.OPEN, EventStatus.CLOSED);
+        List<Event> expected = List.of(mock(Event.class));
+        when(eventDAO.getEventsForGuild("guild-1", statuses, 5)).thenReturn(expected);
+
+        // Act
+        List<Event> actual = underTest.getEventsForGuild("guild-1", statuses, 5);
+
+        // Assert
+        assertThat(actual).isEqualTo(expected);
+        verify(eventDAO, times(1)).getEventsForGuild("guild-1", statuses, 5);
+    }
+
+    @Test
+    void getEventByIdForGuild_DelegatesToDao() {
+        // Arrange
+        Event expected = mock(Event.class);
+        when(eventDAO.findByIdAndGuildId("event-1", "guild-1")).thenReturn(Optional.of(expected));
+
+        // Act
+        Optional<Event> actual = underTest.getEventByIdForGuild("event-1", "guild-1");
+
+        // Assert
+        assertThat(actual).contains(expected);
+        verify(eventDAO, times(1)).findByIdAndGuildId("event-1", "guild-1");
+    }
+
+    @Test
     void deleteEventById_deletesEvent_WhenEventExists() {
         // Arrange
         var eventId = "1";


### PR DESCRIPTION
## Summary
- Add guild-scoped `/list-events` and `/event-info` organizer commands.
- Add organizer summary formatting for roster, waitlist, status, channel, and message IDs.
- Add Discord-side `default_member_permissions` metadata while keeping server-side permission checks.
- Add a live Discord smoke-test checklist and README command updates.

## Validation
- `git diff --check`
- `mise exec -- mvn -ntp -Dmaven.repo.local=.m2/repository test` — 403 tests passed
- `mise exec -- mvn -ntp -Dmaven.repo.local=.m2/repository verify` — 403 unit tests and 108 integration tests passed

## Notes
- Live Discord smoke testing still requires a local `.env` with Discord credentials and a test server.
- The previous hardening checkpoint was already pushed to `main`; this PR contains only the follow-up organizer UX and smoke-test documentation commits.